### PR TITLE
Adding xdaq control

### DIFF
--- a/gemLevelOneFM/duck/gemLevelOne.xml
+++ b/gemLevelOneFM/duck/gemLevelOne.xml
@@ -1,65 +1,83 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" user="gemdev" path="JoseTesting/template">
-  <FunctionManager name="template" 
-		   hostname="gem904daq01"
-		   port="10000" 
-		   qualifiedResourceType="rcms.fm.resource.qualifiedresource.FunctionManager" 
-		   sourceURL="http://gem904daq01:10000/functionmanagers/gemlevelOneFM.jar" 
+<Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" user="gemdev" path="JaredTesting/gemLevelOne">
+  <FunctionManager name="gemLevelOne"
+		   hostname="gem904daq01.cern.ch"
+		   port="10000"
+		   qualifiedResourceType="rcms.fm.resource.qualifiedresource.FunctionManager"
+		   sourceURL="http://gem904daq01.cern.ch:10000/functionmanagers/gemlevelOneFM.jar"
 		   className="rcms.fm.app.gemfm.GEMFunctionManager">
     <!-- Asyncrhonous configuration -->
-    <configFile>&lt;root&gt;
-&lt;rcmsWatchover&gt;
-&lt;xdaq:watchover xmlns:xdaq="http://xdaq.web.cern.ch/xdaq/xsd/2005/ErrorNotification-11.xsd"&gt;rcmsexampleapplication&lt;/xdaq:watchover&gt;
-&lt;/rcmsWatchover&gt;
-&lt;/root&gt;</configFile>
+    <!-- <configFile> -->
+    <!--   <root> -->
+    <!--     <rcmsWatchover> -->
+    <!--       <xdaq:watchover xmlns:xdaq="http://xdaq.web.cern.ch/xdaq/xsd/2005/ErrorNotification-11.xsd">rcmsexampleapplication</xdaq:watchover> -->
+    <!--     </rcmsWatchover> -->
+    <!--   </root> -->
+    <!-- </configFile> -->
     <!-- GEMSupervisor XDAQ Application -->
-    <XdaqExecutive hostname="gem904daq04.cern.ch" port="20000"
-                   urn="urn:xdaq-application:lid=0"
+    <!-- logURL="file:/tmp/sturdy/local_for_GEM_tests.log" -->
+    <!-- logURL="xml:gem904daq01:10010" -->
+
+    <!-- job controls -->
+    <Service name="jobcontrol"
+             hostname="gem904daq01.cern.ch" port="39999" urn="/urn:xdaq-application:lid=10"
+             qualifiedResourceType="rcms.fm.resource.qualifiedresource.JobControl" />
+    <!-- GEMSupervisor XDAQ Application -->
+    <!-- logURL="xml:gem904daq01:10010" -->
+    <!-- logURL="file:/tmp/local_for_GEM_tests.log" -->
+    <XdaqExecutive hostname="gem904daq01.cern.ch" port="20000"
+                   urn="/urn:xdaq-application:lid=0"
                    qualifiedResourceType="rcms.fm.resource.qualifiedresource.XdaqExecutive"
                    instance="0"
                    pathToExecutive="/opt/xdaq/bin/xdaq.exe"
                    unixUser="sturdy"
-                   logLevel="DEBUG"
-                   logURL="file:/tmp/local_for_GEM_tests.log"
-		   environmentString="HOME=/home/sturdy BUILD_HOME=/home/sturdy/gemdev GEM_OS_PROJECT=cmsgemos LD_LIBRARY_PATH=/home/sturdy/gemdev/cmsgemos/gemHwMonitor/lib/linux/x86_64_slc6:/home/sturdy/gemdev/cmsgemos/gemsupervisor/lib/linux/x86_64_slc6:/home/sturdy/gemdev/cmsgemos/gemhardware/lib/linux/x86_64_slc6:/home/sturdy/gemdev/cmsgemos/gemreadout/lib/linux/x86_64_slc6:/home/sturdy/gemdev/cmsgemos/gemutils/lib/linux/x86_64_slc6:/home/sturdy/gemdev/cmsgemos/gembase/lib/linux/x86_64_slc6:/opt/cactus/lib:/opt/xdaq/lib PATH=/bin:/usr/bin XDAQ_ROOT=/opt/xdaq XDAQ_SETUP_ROOT=/opt/xdaq/share XDAQ_ZONE=gem904 XDAQ_DOCUMENT_ROOT=/data/xdaq/sturdy XDAQ_PLATFORM=x86_64_slc6 XDAQ_OS=linux">
+                   logLevel="INFO"
+                   logURL="file:/tmp/sturdy/local_gemsupervisor_for_GEM_tests.log"
+		   environmentString="HOME=/home/sturdy BUILD_HOME=/home/sturdy/gemdev GEM_OS_PROJECT=cmsgemos LD_LIBRARY_PATH=/home/sturdy/gemdev/cmsgemos/gemHwMonitor/lib/linux/x86_64_slc6:/home/sturdy/gemdev/cmsgemos/gemsupervisor/lib/linux/x86_64_slc6:/home/sturdy/gemdev/cmsgemos/gemhardware/lib/linux/x86_64_slc6:/home/sturdy/gemdev/cmsgemos/gemreadout/lib/linux/x86_64_slc6:/home/sturdy/gemdev/cmsgemos/gemutils/lib/linux/x86_64_slc6:/home/sturdy/gemdev/cmsgemos/gembase/lib/linux/x86_64_slc6:/opt/cactus/lib:/opt/xdaq/lib PATH=/bin:/usr/bin XDAQ_ROOT=/opt/xdaq XDAQ_SETUP_ROOT=/opt/xdaq/share XDAQ_ZONE=gem904 XDAQ_DOCUMENT_ROOT=/data/xdaq/sturdy XDAQ_PLATFORM=x86_64_slc6 XDAQ_OS=linux GEM_PYTHON_PATH=/home/sturdy/gemdev/cmsgemos GEM_ADDRESS_TABLE_PATH=/home/sturdy/gemdev/cmsgemos/setup/etc/addresstables uHALROOT=/opt/cactus AMC13_ADDRESS_TABLE_PATH=/opt/cactus/etc/amc13">
       <!-- <configFile location="file">/home/sturdy/gemdev/gem-daq-code/gemdaq-testing/gemsupervisor/xml/gemsupervisor_new.xml</configFile> -->
-      <configFile location="file">/home/sturdy/gemdev/GEM-CMS-FM/gemLevelOneFM/duck/gemsupervisor_gem904daq01.xml</configFile>
+      <configFile location="file">/home/sturdy/tmp/gemsupervisor_gem904daq01.xml</configFile>
     </XdaqExecutive>
-    <!-- job control -->
-    <Service name="jobcontrol"
-             hostname="gem904daq01.cern.ch" port="39999" urn="/urn:xdaq-application:lid=10"
-             qualifiedResourceType="rcms.fm.resource.qualifiedresource.JobControl" />
-    <Service name="jobcontrol"
-             hostname="gem904daq04.cern.ch" port="39999" urn="/urn:xdaq-application:lid=10"
-             qualifiedResourceType="rcms.fm.resource.qualifiedresource.JobControl" />
+
     <!-- GEM XDAQ Applications-->
-    <XdaqApplication className="gem::supervisor::GEMSupervisor" hostname="gem904daq04.cern.ch" port="20000"
-                     urn="urn:xdaq-application:lid=254"
+    <XdaqApplication className="gem::supervisor::GEMSupervisor"
+                     hostname="gem904daq01.cern.ch" port="20000"
+                     urn="/urn:xdaq-application:lid=254"
                      qualifiedResourceType="rcms.fm.resource.qualifiedresource.XdaqApplication"
+                     role="gem904"
                      instance="0" />
+    <XdaqApplication className="gem::hw::amc13::AMC13Manager"
+                     hostname="gem904daq01.cern.ch" port="20000"
+                     urn="/urn:xdaq-application:lid=255"
+                     qualifiedResourceType="rcms.fm.resource.qualifiedresource.XdaqApplication"
+                     role="gem904"
+                     instance="0" />
+
     <!-- <XdaqApplication className="gem::hw::glib::GLIBManager" hostname="gem904daq02.cern.ch" port="20000"
-                     urn="urn:xdaq-application:gem::hw::glib::GLIBManager:lid=30"
+                     urn="/urn:xdaq-application:lid=30"
                      qualifiedResourceType="rcms.fm.resource.qualifiedresource.XdaqApplication"
                      instance="0" />
     <XdaqApplication className="gem::hw::optohybrid::OptoHybridManager" hostname="gem904daq02.cern.ch" port="20000"
-                     urn="urn:xdaq-application:gem::hw::optohybrid::OptoHybridManager:lid=50"
+                     urn="/urn:xdaq-application:lid=50"
                      qualifiedResourceType="rcms.fm.resource.qualifiedresource.XdaqApplication"
                      instance="0" />
     <XdaqApplication className="gem::hw::amc13::AMC13Manager" hostname="gem904daq02.cern.ch" port="20000"
-                     urn="urn:xdaq-application:gem::hw::amc13::AMC13Manager:lid=255"
+                     urn="/urn:xdaq-application:lid=255"
                      qualifiedResourceType="rcms.fm.resource.qualifiedresource.XdaqApplication"
                      instance="0" />
     <XdaqApplication className="gem::hw::amc13::AMC13Readout" hostname="gem904daq02.cern.ch" port="20000"
-                     urn="urn:xdaq-application:gem::hw::amc13::AMC13Readout:lid=260"
+                     urn="/urn:xdaq-application:lid=260"
                      qualifiedResourceType="rcms.fm.resource.qualifiedresource.XdaqApplication"
                      instance="0" /> -->
     <!-- TCDS XDAQ applications -->
-    <!-- <XdaqApplication className="tcds::pi::PIController" hostname="tcds-control-904.cms904" port="20000"
-                     urn="urn:xdaq-application:lid=503"
+    <!--
+    <XdaqApplication className="tcds::pi::PIController"
+                     hostname="tcds-control-904.cms904" port="20000"
+                     urn="/urn:xdaq-application:lid=503"
                      qualifiedResourceType="rcms.fm.resource.qualifiedresource.XdaqApplication"
                      instance="0" />
-    <XdaqApplication className="tcds::ici::ICIController" hostname="tcds-control-904.cms904" port="20000"
-                     urn="urn:xdaq-application:lid=303"
+    <XdaqApplication className="tcds::ici::ICIController"
+                     hostname="tcds-control-904.cms904" port="20000"
+                     urn="/urn:xdaq-application:lid=303"
                      qualifiedResourceType="rcms.fm.resource.qualifiedresource.XdaqApplication"
                      instance="0" /> -->
     <!-- FEDKit XDAQ Applications - TO BE ADDED -->

--- a/gemLevelOneFM/duck/gemLevelOneP5.xml
+++ b/gemLevelOneFM/duck/gemLevelOneP5.xml
@@ -1,63 +1,82 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" user="gemdev" path="JoseTesting/template">
-  <FunctionManager name="template"
-		   hostname="localhost"
+<Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" user="gemdev" path="JaredTesting/gemLevelOne">
+  <FunctionManager name="gemLevelOne"
+		   hostname="cmsrc-gemdev.cms"
 		   port="40000"
 		   qualifiedResourceType="rcms.fm.resource.qualifiedresource.FunctionManager" 
 		   sourceURL="http://cmsrc-gemdev.cms:40000/functionmanagers/JoseTesting/gemlevelOneFM.jar" 
 		   className="rcms.fm.app.gemfm.GEMFunctionManager">
     <!-- Asyncrhonous configuration -->
-    <configFile>&lt;root&gt;
-&lt;rcmsWatchover&gt;
-&lt;xdaq:watchover xmlns:xdaq="http://xdaq.web.cern.ch/xdaq/xsd/2005/ErrorNotification-11.xsd"&gt;rcmsexampleapplication&lt;/xdaq:watchover&gt;
-&lt;/rcmsWatchover&gt;
-&lt;/root&gt;</configFile>
+    <!-- <configFile> -->
+    <!--   <root> -->
+    <!--     <rcmsWatchover> -->
+    <!--       <xdaq:watchover xmlns:xdaq="http://xdaq.web.cern.ch/xdaq/xsd/2005/ErrorNotification-11.xsd">rcmsexampleapplication</xdaq:watchover> -->
+    <!--     </rcmsWatchover> -->
+    <!--   </root> -->
+    <!-- </configFile> -->
     <!-- GEMSupervisor XDAQ Application -->
-    <XdaqExecutive hostname="srv-s2g18-33-01.cms" port="40100"
+    <!-- logURL="file:/tmp/gemdev/local_for_GEM_tests.log" -->
+    <!-- logURL="xml:cmsrc-gemdev:40010" -->
+
+    <!-- job control -->
+    <Service name="jobcontrol"
+             hostname="gem-daq01.cms" port="39999" urn="/urn:xdaq-application:lid=10"
+             qualifiedResourceType="rcms.fm.resource.qualifiedresource.JobControl" />
+
+    <!-- xdaq executives -->
+    <XdaqExecutive hostname="gem-daq01.cms" port="40100"
                    urn="urn:xdaq-application:lid=0"
                    qualifiedResourceType="rcms.fm.resource.qualifiedresource.XdaqExecutive"
                    instance="0"
                    pathToExecutive="/opt/xdaq/bin/xdaq.exe"
                    unixUser="gemdev"
-                   logLevel="DEBUG"
-                   logURL="file:/tmp/local_for_GEM_tests.log"
-		   environmentString="HOME=/nfshome0/gemdev BUILD_HOME=/nfshome0/gemdev/src GEM_OS_PROJECT=cmsgemos LD_LIBRARY_PATH=/nfshome0/gemdev/src/cmsgemos/gemsupervisor/lib/linux/x86_64_slc6:/nfshome0/gemdev/src/cmsgemos/gemhardware/lib/linux/x86_64_slc6:/nfshome0/gemdev/src/cmsgemos/gemreadout/lib/linux/x86_64_slc6:/nfshome0/gemdev/src/cmsgemos/gemutils/lib/linux/x86_64_slc6:/nfshome0/gemdev/src/cmsgemos/gembase/lib/linux/x86_64_slc6:/opt/cactus/lib:/opt/xdaq/lib PATH=/bin:/usr/bin XDAQ_ROOT=/opt/xdaq XDAQ_SETUP_ROOT=/opt/xdaq/share XDAQ_ZONE=gem-daq01 XDAQ_DOCUMENT_ROOT=/nfshome0/gemdev/xdaq/htdocs XDAQ_PLATFORM=x86_64_slc6 XDAQ_OS=linux">
-      <configFile location="file">/home/jose/GEM_Commissioning/NewTemplate/GEM-CMS-FM/gemLevelOneFM/duck/gemsupervisor_P5.xml</configFile>
+                   logLevel="INFO"
+                   logURL="file:/tmp/gemdev/local_for_GEM_tests.log"
+		   environmentString="HOME=/nfshome0/gemdev BUILD_HOME=/nfshome0/gemdev/src GEM_OS_PROJECT=cmsgemos LD_LIBRARY_PATH=/nfshome0/gemdev/src/cmsgemos/gemsupervisor/lib/linux/x86_64_slc6:/nfshome0/gemdev/src/cmsgemos/gemhardware/lib/linux/x86_64_slc6:/nfshome0/gemdev/src/cmsgemos/gemreadout/lib/linux/x86_64_slc6:/nfshome0/gemdev/src/cmsgemos/gemutils/lib/linux/x86_64_slc6:/nfshome0/gemdev/src/cmsgemos/gembase/lib/linux/x86_64_slc6:/opt/cactus/lib:/opt/xdaq/lib PATH=/bin:/usr/bin XDAQ_ROOT=/opt/xdaq XDAQ_SETUP_ROOT=/opt/xdaq/share XDAQ_ZONE=gem XDAQ_DOCUMENT_ROOT=/nfshome0/gemdev/xdaq/htdocs XDAQ_PLATFORM=x86_64_slc6 XDAQ_OS=linux GEM_PYTHON_PATH=/nfshome0/gemdev/src/cmsgemos/cmsgemos GEM_ADDRESS_TABLE_PATH=/nfshome0/gemdev/src/cmsgemos/cmsgemos/setup/etc/addresstables uHALROOT=/opt/cactus AMC13_ADDRESS_TABLE_PATH=/opt/cactus/etc/amc13">
+      <configFile location="file">/home/sturdy/tmp/gemsupervisor_P5.xml</configFile>
     </XdaqExecutive>
-    <!-- job control -->
-    <Service name="jobcontrol"
-             hostname="srv-s2g18-33-01.cms" port="39999" urn="/urn:xdaq-application:lid=10"
-             qualifiedResourceType="rcms.fm.resource.qualifiedresource.JobControl" />
+
     <!-- GEM XDAQ Applications-->
-    <XdaqApplication className="gem::supervisor::GEMSupervisor" hostname="srv-s2g18-33-01.cms" port="40101"
+    <XdaqApplication className="gem::supervisor::GEMSupervisor"
+                     hostname="gem-daq01.cms" port="40100"
                      urn="urn:xdaq-application:lid=254"
                      qualifiedResourceType="rcms.fm.resource.qualifiedresource.XdaqApplication"
                      instance="0" />
-    <!-- <XdaqApplication className="gem::hw::glib::GLIBManager" hostname="gem904daq01.cern.ch" port="20000"
-                     urn="urn:xdaq-application:gem::hw::glib::GLIBManager:lid=30"
-                     qualifiedResourceType="rcms.fm.resource.qualifiedresource.XdaqApplication"
-                     instance="0" />
-    <XdaqApplication className="gem::hw::optohybrid::OptoHybridManager" hostname="gem904daq01.cern.ch" port="20000"
-                     urn="urn:xdaq-application:gem::hw::optohybrid::OptoHybridManager:lid=50"
-                     qualifiedResourceType="rcms.fm.resource.qualifiedresource.XdaqApplication"
-                     instance="0" />
-    <XdaqApplication className="gem::hw::amc13::AMC13Manager" hostname="gem904daq01.cern.ch" port="20000"
-                     urn="urn:xdaq-application:gem::hw::amc13::AMC13Manager:lid=255"
-                     qualifiedResourceType="rcms.fm.resource.qualifiedresource.XdaqApplication"
-                     instance="0" />
-    <XdaqApplication className="gem::hw::amc13::AMC13Readout" hostname="gem904daq01.cern.ch" port="20000"
-                     urn="urn:xdaq-application:gem::hw::amc13::AMC13Readout:lid=260"
-                     qualifiedResourceType="rcms.fm.resource.qualifiedresource.XdaqApplication"
-                     instance="0" /> -->
+    <!-- <XdaqApplication className="gem::hw::glib::GLIBManager" -->
+    <!--                  hostname="gem904daq01.cern.ch" port="20000" -->
+    <!--                  urn="urn:xdaq-application:lid=30" -->
+    <!--                  qualifiedResourceType="rcms.fm.resource.qualifiedresource.XdaqApplication" -->
+    <!--                  instance="0" /> -->
+    <!-- <XdaqApplication className="gem::hw::optohybrid::OptoHybridManager" -->
+    <!--                  hostname="gem904daq01.cern.ch" port="20000" -->
+    <!--                  urn="urn:xdaq-application:lid=50" -->
+    <!--                  qualifiedResourceType="rcms.fm.resource.qualifiedresource.XdaqApplication" -->
+    <!--                  instance="0" /> -->
+    <!-- <XdaqApplication className="gem::hw::amc13::AMC13Manager" -->
+    <!--                  hostname="gem904daq01.cern.ch" port="20000" -->
+    <!--                  urn="urn:xdaq-application:lid=255" -->
+    <!--                  qualifiedResourceType="rcms.fm.resource.qualifiedresource.XdaqApplication" -->
+    <!--                  instance="0" /> -->
+    <!-- <XdaqApplication className="gem::hw::amc13::AMC13Readout" -->
+    <!--                  hostname="gem904daq01.cern.ch" port="20000" -->
+    <!--                  urn="urn:xdaq-application:lid=260" -->
+    <!--                  qualifiedResourceType="rcms.fm.resource.qualifiedresource.XdaqApplication" -->
+    <!--                  instance="0" /> -->
+
     <!-- TCDS XDAQ applications -->
-    <!-- <XdaqApplication className="tcds::pi::PIController" hostname="tcds-control-904.cms904" port="20000"
-                     urn="urn:xdaq-application:lid=503"
-                     qualifiedResourceType="rcms.fm.resource.qualifiedresource.XdaqApplication"
+    <XdaqApplication className="tcds::pi::PIController"
+                     hostname="tcds-control-csc-pri.cms" port="2104"
+                     urn="urn:xdaq-application:lid=501"
+                     role="tcds"
+                     qualifiedResourceType="rcms.fm.resource.qualifiedresource.XdaqServiceApplication"
                      instance="0" />
-    <XdaqApplication className="tcds::ici::ICIController" hostname="tcds-control-904.cms904" port="20000"
-                     urn="urn:xdaq-application:lid=303"
-                     qualifiedResourceType="rcms.fm.resource.qualifiedresource.XdaqApplication"
-                     instance="0" /> -->
+    <XdaqApplication className="tcds::ici::ICIController"
+                     hostname="tcds-control-csc-pri.cms" port="2104"
+                     urn="urn:xdaq-application:lid=301"
+                     role="tcds"
+                     qualifiedResourceType="rcms.fm.resource.qualifiedresource.XdaqServiceApplication"
+                     instance="0" />
+
     <!-- FEDKit XDAQ Applications - TO BE ADDED -->
   </FunctionManager>
 </Configuration>

--- a/gemLevelOneFM/duck/gemsupervisor_P5.xml
+++ b/gemLevelOneFM/duck/gemsupervisor_P5.xml
@@ -3,7 +3,7 @@
 	      xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
 	      xmlns:xc="http://xdaq.web.cern.ch/xdaq/xsd/2004/XMLConfiguration-30">
 
-  <xc:Context url="http://srv-s2g18-33-01.cms:40101">
+  <xc:Context url="http://gem-daq01.cms:40100">
     <xc:Application class="gem::hw::glib::GLIBManager" id="30" instance="0" network="local">
       <properties xmlns="urn:xdaq-application:gem::hw::glib::GLIBManager"
 		  xsi:type="soapenc:Struct">
@@ -69,7 +69,7 @@
           <ConnectionFile     xsi:type="xsd:string">connections.xml</ConnectionFile>
 	  <CardName           xsi:type="xsd:string">gem.shelf01.amc13</CardName>
           <AMCInputEnableList xsi:type="xsd:string">3</AMCInputEnableList>
-          <AMCIgnoreTTSList   xsi:type="xsd:string">0-2,4-15 </AMCIgnoreTTSList>
+          <AMCIgnoreTTSList   xsi:type="xsd:string">1-2,4-12 </AMCIgnoreTTSList>
 
           <EnableDAQLink       xsi:type="xsd:boolean">true</EnableDAQLink>
           <EnableFakeData      xsi:type="xsd:boolean">false</EnableFakeData>

--- a/gemLevelOneFM/duck/gemsupervisor_gem904daq01.xml
+++ b/gemLevelOneFM/duck/gemsupervisor_gem904daq01.xml
@@ -4,63 +4,63 @@
 	      xmlns:xc="http://xdaq.web.cern.ch/xdaq/xsd/2004/XMLConfiguration-30">
 
   <xc:Context url="http://gem904daq01:20000">
-    <xc:Application class="gem::hw::glib::GLIBManager" id="30" instance="0" network="local">
-      <properties xmlns="urn:xdaq-application:gem::hw::glib::GLIBManager"
-		  xsi:type="soapenc:Struct">
-	<AMCSlots       xsi:type="xsd:string">2</AMCSlots> <!-- I AM A TERRIBLE THING-->
-	<ConnectionFile xsi:type="xsd:string">connections.xml</ConnectionFile>
-	<AllGLIBsInfo xsi:type="soapenc:Array"  soapenc:arrayType="xsd:ur-type[12]"> <!-- I AM A TERRIBLE THING-->
-          <GLIBInfo   xsi:type="soapenc:Struct" soapenc:position="1"> <!--  position must be slot-1  -->
-            <crateID  xsi:type="xsd:integer">1</crateID>
-            <slot     xsi:type="xsd:integer">2</slot>
-            <present  xsi:type="xsd:boolean">true</present>
-            <sbitSource    xsi:type="xsd:integer">5</sbitSource>
-          </GLIBInfo>
-	</AllGLIBsInfo>
-      </properties>
-    </xc:Application>
+    <!-- <xc:Application class="gem::hw::glib::GLIBManager" id="30" instance="0" network="local"> -->
+    <!--   <properties xmlns="urn:xdaq-application:gem::hw::glib::GLIBManager" -->
+    <!--     	  xsi:type="soapenc:Struct"> -->
+    <!--     <AMCSlots       xsi:type="xsd:string">2</AMCSlots> <!-\- I AM A TERRIBLE THING-\-> -->
+    <!--     <ConnectionFile xsi:type="xsd:string">connections.xml</ConnectionFile> -->
+    <!--     <AllGLIBsInfo xsi:type="soapenc:Array"  soapenc:arrayType="xsd:ur-type[12]"> <!-\- I AM A TERRIBLE THING-\-> -->
+    <!--       <GLIBInfo   xsi:type="soapenc:Struct" soapenc:position="1"> <!-\-  position must be slot-1  -\-> -->
+    <!--         <crateID  xsi:type="xsd:integer">1</crateID> -->
+    <!--         <slot     xsi:type="xsd:integer">2</slot> -->
+    <!--         <present  xsi:type="xsd:boolean">true</present> -->
+    <!--         <sbitSource    xsi:type="xsd:integer">5</sbitSource> -->
+    <!--       </GLIBInfo> -->
+    <!--     </AllGLIBsInfo> -->
+    <!--   </properties> -->
+    <!-- </xc:Application> -->
 
-    <xc:Application class="gem::hw::optohybrid::OptoHybridManager" id="50" instance="0" network="local">
-      <properties xmlns="urn:xdaq-application:gem::hw::optohybrid::OptoHybridManager"
-		  xsi:type="soapenc:Struct">
-	<ConnectionFile xsi:type="xsd:string">connections.xml</ConnectionFile>
-	<AllOptoHybridsInfo xsi:type="soapenc:Array"  soapenc:arrayType="xsd:ur-type[144]"><!-- MAX_OH_PER_AMC(12) * MAX_AMC_PER_UTCA(12)-->
-          <OptoHybridInfo   xsi:type="soapenc:Struct" soapenc:position="12"> <!-- position must be (slot-1)*MAX_OH_PER_AMC(12)+link -->
-            <crateID xsi:type="xsd:integer">1</crateID>
-            <slot    xsi:type="xsd:integer">2</slot>
-            <link    xsi:type="xsd:integer">0</link>
-            <present xsi:type="xsd:boolean">true</present>
+    <!-- <xc:Application class="gem::hw::optohybrid::OptoHybridManager" id="50" instance="0" network="local"> -->
+    <!--   <properties xmlns="urn:xdaq-application:gem::hw::optohybrid::OptoHybridManager" -->
+    <!--     	  xsi:type="soapenc:Struct"> -->
+    <!--     <ConnectionFile xsi:type="xsd:string">connections.xml</ConnectionFile> -->
+    <!--     <AllOptoHybridsInfo xsi:type="soapenc:Array"  soapenc:arrayType="xsd:ur-type[144]"><!-\- MAX_OH_PER_AMC(12) * MAX_AMC_PER_UTCA(12)-\-> -->
+    <!--       <OptoHybridInfo   xsi:type="soapenc:Struct" soapenc:position="12"> <!-\- position must be (slot-1)*MAX_OH_PER_AMC(12)+link -\-> -->
+    <!--         <crateID xsi:type="xsd:integer">1</crateID> -->
+    <!--         <slot    xsi:type="xsd:integer">2</slot> -->
+    <!--         <link    xsi:type="xsd:integer">0</link> -->
+    <!--         <present xsi:type="xsd:boolean">true</present> -->
 
-            <triggerSource xsi:type="xsd:integer">0</triggerSource>
+    <!--         <triggerSource xsi:type="xsd:integer">0</triggerSource> -->
 
-            <SBitConfig xsi:type="soapenc:Struct">
-              <Mode       xsi:type="xsd:unsignedShort">1</Mode>
-              <Output0Src xsi:type="xsd:unsignedShort">0</Output0Src>
-              <Output1Src xsi:type="xsd:unsignedShort">1</Output1Src>
-              <Output2Src xsi:type="xsd:unsignedShort">2</Output2Src>
-              <Output3Src xsi:type="xsd:unsignedShort">3</Output3Src>
-              <Output4Src xsi:type="xsd:unsignedShort">4</Output4Src>
-              <Output5Src xsi:type="xsd:unsignedShort">5</Output5Src>
-            </SBitConfig>
+    <!--         <SBitConfig xsi:type="soapenc:Struct"> -->
+    <!--           <Mode       xsi:type="xsd:unsignedShort">1</Mode> -->
+    <!--           <Output0Src xsi:type="xsd:unsignedShort">0</Output0Src> -->
+    <!--           <Output1Src xsi:type="xsd:unsignedShort">1</Output1Src> -->
+    <!--           <Output2Src xsi:type="xsd:unsignedShort">2</Output2Src> -->
+    <!--           <Output3Src xsi:type="xsd:unsignedShort">3</Output3Src> -->
+    <!--           <Output4Src xsi:type="xsd:unsignedShort">4</Output4Src> -->
+    <!--           <Output5Src xsi:type="xsd:unsignedShort">5</Output5Src> -->
+    <!--         </SBitConfig> -->
 
-            <CommonVFATSettings xsi:type="soapenc:Struct">
-              <ContReg0    xsi:type="xsd:unsignedShort"> 0x37</ContReg0   >
-              <ContReg2    xsi:type="xsd:unsignedShort"> 0x30</ContReg2   >
-              <IPreampIn   xsi:type="xsd:unsignedShort">  168</IPreampIn  >
-              <IPreampFeed xsi:type="xsd:unsignedShort">   80</IPreampFeed>
-              <IPreampOut  xsi:type="xsd:unsignedShort">  150</IPreampOut >
-              <IShaper     xsi:type="xsd:unsignedShort">  150</IShaper    >
-              <IShaperFeed xsi:type="xsd:unsignedShort">  100</IShaperFeed>
-              <IComp       xsi:type="xsd:unsignedShort">   75</IComp      >
-              <Latency     xsi:type="xsd:unsignedShort">  159</Latency    >
-              <VThreshold1 xsi:type="xsd:unsignedShort">   35</VThreshold1>
-              <VThreshold2 xsi:type="xsd:unsignedShort">    0</VThreshold2>
-            </CommonVFATSettings>
-          </OptoHybridInfo>
+    <!--         <CommonVFATSettings xsi:type="soapenc:Struct"> -->
+    <!--           <ContReg0    xsi:type="xsd:unsignedShort"> 0x37</ContReg0   > -->
+    <!--           <ContReg2    xsi:type="xsd:unsignedShort"> 0x30</ContReg2   > -->
+    <!--           <IPreampIn   xsi:type="xsd:unsignedShort">  168</IPreampIn  > -->
+    <!--           <IPreampFeed xsi:type="xsd:unsignedShort">   80</IPreampFeed> -->
+    <!--           <IPreampOut  xsi:type="xsd:unsignedShort">  150</IPreampOut > -->
+    <!--           <IShaper     xsi:type="xsd:unsignedShort">  150</IShaper    > -->
+    <!--           <IShaperFeed xsi:type="xsd:unsignedShort">  100</IShaperFeed> -->
+    <!--           <IComp       xsi:type="xsd:unsignedShort">   75</IComp      > -->
+    <!--           <Latency     xsi:type="xsd:unsignedShort">  159</Latency    > -->
+    <!--           <VThreshold1 xsi:type="xsd:unsignedShort">   35</VThreshold1> -->
+    <!--           <VThreshold2 xsi:type="xsd:unsignedShort">    0</VThreshold2> -->
+    <!--         </CommonVFATSettings> -->
+    <!--       </OptoHybridInfo> -->
 
-	</AllOptoHybridsInfo>
-      </properties>
-    </xc:Application>
+    <!--     </AllOptoHybridsInfo> -->
+    <!--   </properties> -->
+    <!-- </xc:Application> -->
 
     <xc:Application class="gem::hw::amc13::AMC13Manager" id="255" instance="3" network="local">
       <properties xmlns="urn:xdaq-application:gem::hw::amc13::AMC13Manager"
@@ -68,8 +68,8 @@
         <amc13ConfigParams xsi:type="soapenc:Struct">
           <ConnectionFile     xsi:type="xsd:string">connections.xml</ConnectionFile>
 	  <CardName           xsi:type="xsd:string">gem.shelf01.amc13</CardName>
-          <AMCInputEnableList xsi:type="xsd:string">3</AMCInputEnableList>
-          <AMCIgnoreTTSList   xsi:type="xsd:string">0-2,4-15 </AMCIgnoreTTSList>
+          <AMCInputEnableList xsi:type="xsd:string">2</AMCInputEnableList>
+          <AMCIgnoreTTSList   xsi:type="xsd:string">1,3-12</AMCIgnoreTTSList>
 
           <EnableDAQLink       xsi:type="xsd:boolean">true</EnableDAQLink>
           <EnableFakeData      xsi:type="xsd:boolean">false</EnableFakeData>
@@ -114,31 +114,32 @@
       </properties>
     </xc:Application>
 
-    <xc:Application class="gem::hw::amc13::AMC13Readout" id="260" instance="0" network="local">
-      <properties xmlns="urn:xdaq-application:gem::hw::amc13::AMC13Readout"
-		  xsi:type="soapenc:Struct">
-        <ConnectionFile  xsi:type="xsd:string">connections.xml</ConnectionFile>
-        <DeviceName      xsi:type="xsd:string">AMC13</DeviceName>
-        <CardName        xsi:type="xsd:string">gem.shelf01.amc13</CardName>
-        <crateID         xsi:type="xsd:integer">1</crateID>
-        <slot            xsi:type="xsd:integer">13</slot>
-        <ReadoutSettings xsi:type="soapenc:Struct">
-          <runType        xsi:type="xsd:string">ThresholdScan</runType>
-          <fileName       xsi:type="xsd:string">test</fileName>
-          <outputType     xsi:type="xsd:string">BIN</outputType>
-          <outputLocation xsi:type="xsd:string">/tmp/</outputLocation>
-          <setupLocation  xsi:type="xsd:string">CERN904</setupLocation>
-        </ReadoutSettings>
-      </properties>
-    </xc:Application>
+    <!-- <xc:Application class="gem::hw::amc13::AMC13Readout" id="260" instance="0" network="local"> -->
+    <!--   <properties xmlns="urn:xdaq-application:gem::hw::amc13::AMC13Readout" -->
+    <!--     	  xsi:type="soapenc:Struct"> -->
+    <!--     <ConnectionFile  xsi:type="xsd:string">connections.xml</ConnectionFile> -->
+    <!--     <DeviceName      xsi:type="xsd:string">AMC13</DeviceName> -->
+    <!--     <CardName        xsi:type="xsd:string">gem.shelf01.amc13</CardName> -->
+    <!--     <crateID         xsi:type="xsd:integer">1</crateID> -->
+    <!--     <slot            xsi:type="xsd:integer">13</slot> -->
+    <!--     <ReadoutSettings xsi:type="soapenc:Struct"> -->
+    <!--       <runType        xsi:type="xsd:string">ThresholdScan</runType> -->
+    <!--       <fileName       xsi:type="xsd:string">test</fileName> -->
+    <!--       <outputType     xsi:type="xsd:string">BIN</outputType> -->
+    <!--       <outputLocation xsi:type="xsd:string">/tmp/</outputLocation> -->
+    <!--       <setupLocation  xsi:type="xsd:string">CERN904</setupLocation> -->
+    <!--     </ReadoutSettings> -->
+    <!--   </properties> -->
+    <!-- </xc:Application> -->
 
-    <xc:Application class="gem::supervisor::GEMSupervisor" id="254" instance="0" network="local">
+    <xc:Application class="gem::supervisor::GEMSupervisor" id="254" instance="0" network="local" logLevel="INFO">
       <properties xmlns="urn:xdaq-application:GEMSupervisor"
 		  xsi:type="soapenc:Struct">
         <UseLocalDB        xsi:type="xsd:boolean">false</UseLocalDB>
-        <HandleTCDS        xsi:type="xsd:boolean">false</HandleTCDS>
+        <HandleTCDS        xsi:type="xsd:boolean">true</HandleTCDS>
         <UseLocalReadout   xsi:type="xsd:boolean">true</UseLocalReadout>
         <UseFedKitReadout  xsi:type="xsd:boolean">false</UseFedKitReadout>
+        <ReportStateToRCMS xsi:type="xsd:boolean">true</ReportStateToRCMS>
 
         <DatabaseInfo xsi:type="soapenc:Struct">
           <dbName xsi:type="xsd:string">ldqm_test_db</dbName>
@@ -149,7 +150,7 @@
 
           <setupTag xsi:type="xsd:string">ThresholdScan</setupTag>
           <runPeriod xsi:type="xsd:string">2017T</runPeriod>
-          <setupLocation xsi:type="xsd:string">CERNP5</setupLocation>
+          <setupLocation xsi:type="xsd:string">CERN904</setupLocation>
         </DatabaseInfo>
 
         <ScanInfo xsi:type="soapenc:Struct">
@@ -186,17 +187,31 @@
 
   </xc:Context>
 
-  <xc:Context url="http://gem904daq01:10000/rcms">
-    <xc:Application class="RCMSStateListener" id="50" instance="0" network="local" path="/services/replycommandreceiver" />
-    <xc:Module>${XDAQ_ROOT}/lib/libxdaq2rc.so</xc:Module>
-  </xc:Context>
-
   <xc:Context url="http://localhost:12107">
     <xc:Application class="tcds::ici::ICIController" id="303" instance="0" network="local">
+      <properties xmlns="urn:xdaq-application:GEMSupervisor"
+		  xsi:type="soapenc:Struct">
+	<rcmsStateListener xsi:type="soapenc:Struct">
+          <classname xsi:type="xsd:string">RCMSStateListener</classname>
+          <instance  xsi:type="xsd:unsignedInt">0</instance>
+        </rcmsStateListener>
+      </properties>
     </xc:Application>
 
     <xc:Application class="tcds::pi::PIController"   id="503" instance="0" network="local">
+      <properties xmlns="urn:xdaq-application:GEMSupervisor"
+		  xsi:type="soapenc:Struct">
+	<rcmsStateListener xsi:type="soapenc:Struct">
+          <classname xsi:type="xsd:string">RCMSStateListener</classname>
+          <instance  xsi:type="xsd:unsignedInt">0</instance>
+        </rcmsStateListener>
+      </properties>
     </xc:Application>
+  </xc:Context>
+
+  <xc:Context url="http://gem904daq01.cern.ch:10000/rcms">
+    <xc:Application class="RCMSStateListener" id="50" instance="0" network="local" path="/services/replycommandreceiver" />
+    <xc:Module>${XDAQ_ROOT}/lib/libxdaq2rc.so</xc:Module>
   </xc:Context>
 
 </xc:Partition>

--- a/gemLevelOneFM/duck/gemsupervisor_gem904daq01.xml
+++ b/gemLevelOneFM/duck/gemsupervisor_gem904daq01.xml
@@ -4,63 +4,63 @@
 	      xmlns:xc="http://xdaq.web.cern.ch/xdaq/xsd/2004/XMLConfiguration-30">
 
   <xc:Context url="http://gem904daq01:20000">
-    <!-- <xc:Application class="gem::hw::glib::GLIBManager" id="30" instance="0" network="local"> -->
-    <!--   <properties xmlns="urn:xdaq-application:gem::hw::glib::GLIBManager" -->
-    <!--     	  xsi:type="soapenc:Struct"> -->
-    <!--     <AMCSlots       xsi:type="xsd:string">2</AMCSlots> <!-\- I AM A TERRIBLE THING-\-> -->
-    <!--     <ConnectionFile xsi:type="xsd:string">connections.xml</ConnectionFile> -->
-    <!--     <AllGLIBsInfo xsi:type="soapenc:Array"  soapenc:arrayType="xsd:ur-type[12]"> <!-\- I AM A TERRIBLE THING-\-> -->
-    <!--       <GLIBInfo   xsi:type="soapenc:Struct" soapenc:position="1"> <!-\-  position must be slot-1  -\-> -->
-    <!--         <crateID  xsi:type="xsd:integer">1</crateID> -->
-    <!--         <slot     xsi:type="xsd:integer">2</slot> -->
-    <!--         <present  xsi:type="xsd:boolean">true</present> -->
-    <!--         <sbitSource    xsi:type="xsd:integer">5</sbitSource> -->
-    <!--       </GLIBInfo> -->
-    <!--     </AllGLIBsInfo> -->
-    <!--   </properties> -->
-    <!-- </xc:Application> -->
+    <xc:Application class="gem::hw::glib::GLIBManager" id="30" instance="0" network="local">
+      <properties xmlns="urn:xdaq-application:gem::hw::glib::GLIBManager"
+        	  xsi:type="soapenc:Struct">
+        <AMCSlots       xsi:type="xsd:string">2</AMCSlots> <!-- I AM A TERRIBLE THING-->
+        <ConnectionFile xsi:type="xsd:string">connections.xml</ConnectionFile>
+        <AllGLIBsInfo xsi:type="soapenc:Array"  soapenc:arrayType="xsd:ur-type[12]"> <!-- I AM A TERRIBLE THING-->
+          <GLIBInfo   xsi:type="soapenc:Struct" soapenc:position="1"> <!--  position must be slot-1  -->
+            <crateID  xsi:type="xsd:integer">1</crateID>
+            <slot     xsi:type="xsd:integer">2</slot>
+            <present  xsi:type="xsd:boolean">true</present>
+            <sbitSource    xsi:type="xsd:integer">5</sbitSource>
+          </GLIBInfo>
+        </AllGLIBsInfo>
+      </properties>
+    </xc:Application>
 
-    <!-- <xc:Application class="gem::hw::optohybrid::OptoHybridManager" id="50" instance="0" network="local"> -->
-    <!--   <properties xmlns="urn:xdaq-application:gem::hw::optohybrid::OptoHybridManager" -->
-    <!--     	  xsi:type="soapenc:Struct"> -->
-    <!--     <ConnectionFile xsi:type="xsd:string">connections.xml</ConnectionFile> -->
-    <!--     <AllOptoHybridsInfo xsi:type="soapenc:Array"  soapenc:arrayType="xsd:ur-type[144]"><!-\- MAX_OH_PER_AMC(12) * MAX_AMC_PER_UTCA(12)-\-> -->
-    <!--       <OptoHybridInfo   xsi:type="soapenc:Struct" soapenc:position="12"> <!-\- position must be (slot-1)*MAX_OH_PER_AMC(12)+link -\-> -->
-    <!--         <crateID xsi:type="xsd:integer">1</crateID> -->
-    <!--         <slot    xsi:type="xsd:integer">2</slot> -->
-    <!--         <link    xsi:type="xsd:integer">0</link> -->
-    <!--         <present xsi:type="xsd:boolean">true</present> -->
+    <xc:Application class="gem::hw::optohybrid::OptoHybridManager" id="50" instance="0" network="local">
+      <properties xmlns="urn:xdaq-application:gem::hw::optohybrid::OptoHybridManager"
+        	  xsi:type="soapenc:Struct">
+        <ConnectionFile xsi:type="xsd:string">connections.xml</ConnectionFile>
+        <AllOptoHybridsInfo xsi:type="soapenc:Array"  soapenc:arrayType="xsd:ur-type[144]"><!-- MAX_OH_PER_AMC(12) * MAX_AMC_PER_UTCA(12)-->
+          <OptoHybridInfo   xsi:type="soapenc:Struct" soapenc:position="12"> <!-- position must be (slot-1)*MAX_OH_PER_AMC(12)+link -->
+            <crateID xsi:type="xsd:integer">1</crateID>
+            <slot    xsi:type="xsd:integer">2</slot>
+            <link    xsi:type="xsd:integer">0</link>
+            <present xsi:type="xsd:boolean">true</present>
 
-    <!--         <triggerSource xsi:type="xsd:integer">0</triggerSource> -->
+            <triggerSource xsi:type="xsd:integer">0</triggerSource>
 
-    <!--         <SBitConfig xsi:type="soapenc:Struct"> -->
-    <!--           <Mode       xsi:type="xsd:unsignedShort">1</Mode> -->
-    <!--           <Output0Src xsi:type="xsd:unsignedShort">0</Output0Src> -->
-    <!--           <Output1Src xsi:type="xsd:unsignedShort">1</Output1Src> -->
-    <!--           <Output2Src xsi:type="xsd:unsignedShort">2</Output2Src> -->
-    <!--           <Output3Src xsi:type="xsd:unsignedShort">3</Output3Src> -->
-    <!--           <Output4Src xsi:type="xsd:unsignedShort">4</Output4Src> -->
-    <!--           <Output5Src xsi:type="xsd:unsignedShort">5</Output5Src> -->
-    <!--         </SBitConfig> -->
+            <SBitConfig xsi:type="soapenc:Struct">
+              <Mode       xsi:type="xsd:unsignedShort">1</Mode>
+              <Output0Src xsi:type="xsd:unsignedShort">0</Output0Src>
+              <Output1Src xsi:type="xsd:unsignedShort">1</Output1Src>
+              <Output2Src xsi:type="xsd:unsignedShort">2</Output2Src>
+              <Output3Src xsi:type="xsd:unsignedShort">3</Output3Src>
+              <Output4Src xsi:type="xsd:unsignedShort">4</Output4Src>
+              <Output5Src xsi:type="xsd:unsignedShort">5</Output5Src>
+            </SBitConfig>
 
-    <!--         <CommonVFATSettings xsi:type="soapenc:Struct"> -->
-    <!--           <ContReg0    xsi:type="xsd:unsignedShort"> 0x37</ContReg0   > -->
-    <!--           <ContReg2    xsi:type="xsd:unsignedShort"> 0x30</ContReg2   > -->
-    <!--           <IPreampIn   xsi:type="xsd:unsignedShort">  168</IPreampIn  > -->
-    <!--           <IPreampFeed xsi:type="xsd:unsignedShort">   80</IPreampFeed> -->
-    <!--           <IPreampOut  xsi:type="xsd:unsignedShort">  150</IPreampOut > -->
-    <!--           <IShaper     xsi:type="xsd:unsignedShort">  150</IShaper    > -->
-    <!--           <IShaperFeed xsi:type="xsd:unsignedShort">  100</IShaperFeed> -->
-    <!--           <IComp       xsi:type="xsd:unsignedShort">   75</IComp      > -->
-    <!--           <Latency     xsi:type="xsd:unsignedShort">  159</Latency    > -->
-    <!--           <VThreshold1 xsi:type="xsd:unsignedShort">   35</VThreshold1> -->
-    <!--           <VThreshold2 xsi:type="xsd:unsignedShort">    0</VThreshold2> -->
-    <!--         </CommonVFATSettings> -->
-    <!--       </OptoHybridInfo> -->
+            <CommonVFATSettings xsi:type="soapenc:Struct">
+              <ContReg0    xsi:type="xsd:unsignedShort"> 0x37</ContReg0   >
+              <ContReg2    xsi:type="xsd:unsignedShort"> 0x30</ContReg2   >
+              <IPreampIn   xsi:type="xsd:unsignedShort">  168</IPreampIn  >
+              <IPreampFeed xsi:type="xsd:unsignedShort">   80</IPreampFeed>
+              <IPreampOut  xsi:type="xsd:unsignedShort">  150</IPreampOut >
+              <IShaper     xsi:type="xsd:unsignedShort">  150</IShaper    >
+              <IShaperFeed xsi:type="xsd:unsignedShort">  100</IShaperFeed>
+              <IComp       xsi:type="xsd:unsignedShort">   75</IComp      >
+              <Latency     xsi:type="xsd:unsignedShort">  159</Latency    >
+              <VThreshold1 xsi:type="xsd:unsignedShort">   35</VThreshold1>
+              <VThreshold2 xsi:type="xsd:unsignedShort">    0</VThreshold2>
+            </CommonVFATSettings>
+          </OptoHybridInfo>
 
-    <!--     </AllOptoHybridsInfo> -->
-    <!--   </properties> -->
-    <!-- </xc:Application> -->
+        </AllOptoHybridsInfo>
+      </properties>
+    </xc:Application>
 
     <xc:Application class="gem::hw::amc13::AMC13Manager" id="255" instance="3" network="local">
       <properties xmlns="urn:xdaq-application:gem::hw::amc13::AMC13Manager"
@@ -148,13 +148,13 @@
           <dbUser xsi:type="xsd:string">gemdaq</dbUser>
           <dbPass xsi:type="xsd:string">gemdaq</dbPass>
 
-          <setupTag xsi:type="xsd:string">ThresholdScan</setupTag>
+          <setupTag xsi:type="xsd:string">Cosmic</setupTag>
           <runPeriod xsi:type="xsd:string">2017T</runPeriod>
           <setupLocation xsi:type="xsd:string">CERN904</setupLocation>
         </DatabaseInfo>
 
         <ScanInfo xsi:type="soapenc:Struct">
-          <ScanType   xsi:type="xsd:unsignedInt">3</ScanType>
+          <ScanType   xsi:type="xsd:unsignedInt">1</ScanType>
           <ScanMin    xsi:type="xsd:unsignedInt">0</ScanMin>
           <ScanMax    xsi:type="xsd:unsignedInt">101</ScanMax>
           <StepSize   xsi:type="xsd:unsignedInt">1</StepSize>

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
@@ -986,13 +986,13 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                             logger.info(msgPrefix + "sent run number to the supervisor");
                         } catch (XDAQTimeoutException e) {
                             String msg = "Error! XDAQTimeoutException when "
-                                + " trying to send the m_gemFM.RunNumber to the GEM supervisor\n Perhaps this "
+                                + " trying to send the run number to the GEM supervisor\n Perhaps this "
                                 + "application is dead!?";
                             m_gemFM.goToError(msg, e);
                             logger.error(msgPrefix + msg);
                         } catch (XDAQException e) {
                             String msg = "Error! XDAQException when trying "
-                                + "to send the m_gemFM.RunNumber to the GEM supervisor";
+                                + "to send the run number to the GEM supervisor";
                             m_gemFM.goToError(msg, e);
                             logger.error(msgPrefix + msg);
                         }
@@ -1046,13 +1046,13 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                             pam.send();
                         } catch (XDAQTimeoutException e) {
                             String msg = "Error! XDAQTimeoutException when "
-                                + " trying to send the m_gemFM.RunNumber to the EVM\n Perhaps this "
+                                + " trying to send the run number to the EVM\n Perhaps this "
                                 + "application is dead!?";
                             m_gemFM.goToError(msg, e);
                             logger.error(msgPrefix + msg);
                         } catch (XDAQException e) {
                             String msg = "Error! XDAQException when trying "
-                                + "to send the m_gemFM.RunNumber to the EVM";
+                                + "to send the run number to the EVM";
                             m_gemFM.goToError(msg, e);
                             logger.error(msgPrefix + msg);
                         }
@@ -1086,13 +1086,13 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                             pam.send();
                         } catch (XDAQTimeoutException e) {
                             String msg = "Error! XDAQTimeoutException when "
-                                + " trying to send the m_gemFM.RunNumber to the BU\n"
+                                + " trying to send the run number to the BU\n"
                                 + "Perhaps this application is dead!?";
                             m_gemFM.goToError(msg, e);
                             logger.error(msgPrefix + msg);
                         } catch (XDAQException e) {
                             String msg = "Error! XDAQException when trying "
-                                + "to send the m_gemFM.RunNumber to the BU";
+                                + "to send the run number to the BU";
                             m_gemFM.goToError(msg, e);
                             logger.error(msgPrefix + msg);
                         }
@@ -1430,6 +1430,8 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 
             if (m_gemFM.c_gemSupervisors != null) {
                 if (!m_gemFM.c_gemSupervisors.isEmpty()) {
+                    // new run number during resume?
+                    /*
                     XDAQParameter pam = null;
                     // prepare and set for all GEM supervisors the RunType
                     for (QualifiedResource qr : m_gemFM.c_gemSupervisors.getApplications() ){
@@ -1443,21 +1445,22 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                             pam.send();
                         } catch (XDAQTimeoutException e) {
                             String msg = "Error! XDAQTimeoutException: startAction() when "
-                                + " trying to send the m_gemFM.RunNumber to the GEM supervisor\n Perhaps this "
+                                + " trying to send the run number to the GEM supervisor\n Perhaps this "
                                 + "application is dead!?";
                             m_gemFM.goToError(msg, e);
                             logger.error(msgPrefix + msg);
                         } catch (XDAQException e) {
                             String msg = "Error! XDAQException: startAction() when trying "
-                                + "to send the m_gemFM.RunNumber to the GEM supervisor";
+                                + "to send the run number to the GEM supervisor";
                             m_gemFM.goToError(msg, e);
                             logger.error(msgPrefix + msg);
                         }
                     }
+                    */
 
                     try {
-                        logger.info(msgPrefix + "Trying to start GEMSupervisor.");
-                        m_gemFM.c_gemSupervisors.execute(GEMInputs.START);
+                        logger.info(msgPrefix + "Trying to resume GEMSupervisor.");
+                        m_gemFM.c_gemSupervisors.execute(GEMInputs.RESUME);
                     } catch (QualifiedResourceContainerException e) {
                         String msg = e.getMessage();
                         logger.error(msgPrefix + msg);

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
@@ -317,6 +317,8 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 
             logger.info(msgPrefix + "Received Initialize state notification");
 
+            m_gemFM.m_stateNotificationHandler.processNotice(obj);
+
             return;
         } else if (obj instanceof StateEnteredEvent) {
             // triggered by entered state action
@@ -527,6 +529,8 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 
             logger.info(msgPrefix + "Received Reset state notification");
 
+            m_gemFM.m_stateNotificationHandler.processNotice(obj);
+
             return;
         } else if (obj instanceof StateEnteredEvent) {
             // triggered by entered state action
@@ -641,12 +645,10 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 
             logger.info(msgPrefix + "Received Recover state notification");
 
+            m_gemFM.m_stateNotificationHandler.processNotice(obj);
+
             return;
         } else if (obj instanceof StateEnteredEvent) {
-
-            System.out.println("Executing recoverAction");
-            logger.info("Executing recoverAction");
-
             // set action
             m_gemPSet.put(new FunctionManagerParameter<StringT>(GEMParameters.ACTION_MSG,new StringT("recovering")));
 
@@ -682,11 +684,10 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 
             logger.info(msgPrefix + "Received Configure state notification");
 
+            m_gemFM.m_stateNotificationHandler.processNotice(obj);
+
             return;
         } else if (obj instanceof StateEnteredEvent) {
-            System.out.println(msgPrefix + "Executing configureAction");
-            logger.info(msgPrefix + "Executing configureAction");
-
             // set action
             m_gemPSet.put(new FunctionManagerParameter<StringT>(GEMParameters.ACTION_MSG,
                                                                 new StringT("Configure action called")));
@@ -885,9 +886,10 @@ public class GEMEventHandler extends UserStateNotificationHandler {
             /************************************************
              * PUT YOUR CODE HERE
              ***********************************************/
-            // START GEMFSMApplications
-            // ENABLE? ferol/EVM/BU/RU?
-            // START TCDS
+
+            logger.info(msgPrefix + "Received Start state notification");
+
+            m_gemFM.m_stateNotificationHandler.processNotice(obj);
 
             return;
         } else if (obj instanceof StateEnteredEvent) {
@@ -975,6 +977,9 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         try {
                             pam = ((XdaqApplication)qr).getXDAQParameter();
                             pam.select(new String[] {"RunNumber"});
+                            pam.get();
+                            String superRunNumber = pam.getValue("RunNumber");
+                            logger.info(msgPrefix + "got run number " + superRunNumber + " from the supervisor");
                             pam.setValue("RunNumber",m_gemFM.RunNumber.toString());
                             logger.info(msgPrefix + "sending run number to the supervisor");
                             pam.send();
@@ -1035,19 +1040,19 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                             pam = ((XdaqApplication)qr).getXDAQParameter();
                             pam.select(new String[] {"runNumber"});
                             pam.get();
-                            String evmRunNumber = pam.getValue("RunNumber");
-                            logger.info(msgPrefix + "Obtained run number from evm: " + evmRunNumber);
+                            String evmRunNumber = pam.getValue("runNumber");
+                            logger.info(msgPrefix + "Obtained run number from the EVM: " + evmRunNumber);
                             pam.setValue("runNumber",m_gemFM.RunNumber.toString());
                             pam.send();
                         } catch (XDAQTimeoutException e) {
-                            String msg = "Error! XDAQTimeoutException: startAction() when "
-                                + " trying to send the m_gemFM.RunNumber to the GEM supervisor\n Perhaps this "
+                            String msg = "Error! XDAQTimeoutException when "
+                                + " trying to send the m_gemFM.RunNumber to the EVM\n Perhaps this "
                                 + "application is dead!?";
                             m_gemFM.goToError(msg, e);
                             logger.error(msgPrefix + msg);
                         } catch (XDAQException e) {
-                            String msg = "Error! XDAQException: startAction() when trying "
-                                + "to send the m_gemFM.RunNumber to the GEM supervisor";
+                            String msg = "Error! XDAQException when trying "
+                                + "to send the m_gemFM.RunNumber to the EVM";
                             m_gemFM.goToError(msg, e);
                             logger.error(msgPrefix + msg);
                         }
@@ -1075,19 +1080,19 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                             pam = ((XdaqApplication)qr).getXDAQParameter();
                             pam.select(new String[] {"runNumber"});
                             pam.get();
-                            String buRunNumber = pam.getValue("RunNumber");
-                            logger.info(msgPrefix + "Obtained run number from bu: " + buRunNumber);
+                            String buRunNumber = pam.getValue("runNumber");
+                            logger.info(msgPrefix + "Obtained run number from the BU: " + buRunNumber);
                             pam.setValue("runNumber",m_gemFM.RunNumber.toString());
                             pam.send();
                         } catch (XDAQTimeoutException e) {
-                            String msg = "Error! XDAQTimeoutException: startAction() when "
-                                + " trying to send the m_gemFM.RunNumber to the GEM supervisor\n Perhaps this "
-                                + "application is dead!?";
+                            String msg = "Error! XDAQTimeoutException when "
+                                + " trying to send the m_gemFM.RunNumber to the BU\n"
+                                + "Perhaps this application is dead!?";
                             m_gemFM.goToError(msg, e);
                             logger.error(msgPrefix + msg);
                         } catch (XDAQException e) {
-                            String msg = "Error! XDAQException: startAction() when trying "
-                                + "to send the m_gemFM.RunNumber to the GEM supervisor";
+                            String msg = "Error! XDAQException when trying "
+                                + "to send the m_gemFM.RunNumber to the BU";
                             m_gemFM.goToError(msg, e);
                             logger.error(msgPrefix + msg);
                         }
@@ -1160,9 +1165,10 @@ public class GEMEventHandler extends UserStateNotificationHandler {
             /************************************************
              * PUT YOUR CODE HERE
              ***********************************************/
-            // PAUSE TCDS
-            // PAUSE GEMFSMApplications
-            // PAUSE ferol/EVM/BU/RU?
+
+            logger.info(msgPrefix + "Received Pause state notification");
+
+            m_gemFM.m_stateNotificationHandler.processNotice(obj);
 
             return;
         }
@@ -1257,9 +1263,10 @@ public class GEMEventHandler extends UserStateNotificationHandler {
             /************************************************
              * PUT YOUR CODE HERE
              ***********************************************/
-            // STOP TCDS
-            // STOP GEMFSMApplications
-            // STOP ferol/EVM/BU/RU?
+
+            logger.info(msgPrefix + "Received Stop state notification");
+
+            m_gemFM.m_stateNotificationHandler.processNotice(obj);
 
             return;
         }
@@ -1401,9 +1408,10 @@ public class GEMEventHandler extends UserStateNotificationHandler {
             /************************************************
              * PUT YOUR CODE HERE
              ***********************************************/
-            // RESUME ferol/EVM/BU/RU?
-            // RESUME GEMFSMApplications
-            // RESUME TCDS
+
+            logger.info(msgPrefix + "Received Resume state notification");
+
+            m_gemFM.m_stateNotificationHandler.processNotice(obj);
 
             return;
         } else if (obj instanceof StateEnteredEvent) {
@@ -1525,14 +1533,13 @@ public class GEMEventHandler extends UserStateNotificationHandler {
             /************************************************
              * PUT YOUR CODE HERE
              ***********************************************/
-            // HALT TCDS
-            // HALT ferol/EVM/BU/RU?
-            // HALT GEMFSMApplications
+
+            logger.info(msgPrefix + "Received Halt state notification");
+
+            m_gemFM.m_stateNotificationHandler.processNotice(obj);
 
             return;
-        }
-
-        else if (obj instanceof StateEnteredEvent) {
+        } else if (obj instanceof StateEnteredEvent) {
             System.out.println("Executing haltAction");
             logger.info("Executing haltAction");
 
@@ -1628,14 +1635,13 @@ public class GEMEventHandler extends UserStateNotificationHandler {
             /************************************************
              * PUT YOUR CODE HERE
              ***********************************************/
-            // ? TCDS
-            // ? ferol/EVM/BU/RU?
-            // ? GEMFSMApplications
+
+            logger.info(msgPrefix + "Received PrepareTTSTestMode state notification");
+
+            m_gemFM.m_stateNotificationHandler.processNotice(obj);
 
             return;
-        }
-
-        else if (obj instanceof StateEnteredEvent) {
+        } else if (obj instanceof StateEnteredEvent) {
             System.out.println("Executing preparingTestModeAction");
             logger.info("Executing preparingTestModeAction");
 
@@ -1674,14 +1680,13 @@ public class GEMEventHandler extends UserStateNotificationHandler {
             /************************************************
              * PUT YOUR CODE HERE
              ***********************************************/
-            // ? TCDS
-            // ? ferol/EVM/BU/RU?
-            // ? GEMFSMApplications
+
+            logger.info(msgPrefix + "Received TestTTS state notification");
+
+            m_gemFM.m_stateNotificationHandler.processNotice(obj);
 
             return;
-        }
-
-        else if (obj instanceof StateEnteredEvent) {
+        } else if (obj instanceof StateEnteredEvent) {
             System.out.println("Executing testingTTSAction");
             logger.info("Executing testingTTSAction");
 
@@ -1760,6 +1765,8 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 
             logger.info(msgPrefix + "Received ColdResetting state notification");
 
+            m_gemFM.m_stateNotificationHandler.processNotice(obj);
+
             return;
         } else if (obj instanceof StateEnteredEvent) {
             System.out.println("Executing coldResettingAction");
@@ -1800,6 +1807,8 @@ public class GEMEventHandler extends UserStateNotificationHandler {
              ***********************************************/
 
             logger.info(msgPrefix + "Received FixSoftError state notification");
+
+            m_gemFM.m_stateNotificationHandler.processNotice(obj);
 
             return;
         } else if (obj instanceof StateEnteredEvent) {

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
@@ -315,7 +315,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
              * PUT YOUR CODE HERE
              ***********************************************/
 
-            logger.info(msgPrefix + "Recieved Initialize state notification");
+            logger.info(msgPrefix + "Received Initialize state notification");
 
             return;
         } else if (obj instanceof StateEnteredEvent) {
@@ -525,7 +525,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
              * PUT YOUR CODE HERE
              ***********************************************/
 
-            logger.info(msgPrefix + "Recieved Reset state notification");
+            logger.info(msgPrefix + "Received Reset state notification");
 
             return;
         } else if (obj instanceof StateEnteredEvent) {
@@ -639,7 +639,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
              * PUT YOUR CODE HERE
              ***********************************************/
 
-            logger.info(msgPrefix + "Recieved Recover state notification");
+            logger.info(msgPrefix + "Received Recover state notification");
 
             return;
         } else if (obj instanceof StateEnteredEvent) {
@@ -680,7 +680,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
              * PUT YOUR CODE HERE
              ***********************************************/
 
-            logger.info(msgPrefix + "Recieved Configure state notification");
+            logger.info(msgPrefix + "Received Configure state notification");
 
             return;
         } else if (obj instanceof StateEnteredEvent) {
@@ -1758,7 +1758,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
              * PUT YOUR CODE HERE
              ***********************************************/
 
-            logger.info(msgPrefix + "Recieved ColdResetting state notification");
+            logger.info(msgPrefix + "Received ColdResetting state notification");
 
             return;
         } else if (obj instanceof StateEnteredEvent) {
@@ -1799,7 +1799,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
              * PUT YOUR CODE HERE
              ***********************************************/
 
-            logger.info(msgPrefix + "Recieved FixSoftError state notification");
+            logger.info(msgPrefix + "Received FixSoftError state notification");
 
             return;
         } else if (obj instanceof StateEnteredEvent) {
@@ -1884,7 +1884,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
         String msgPrefix = "[GEM FM::" + m_gemFM.m_FMname + "] GEMEventHandler::runningSoftErrorDetectedAction(): ";
 
         if (obj instanceof StateEnteredEvent) {
-            logger.info(msgPrefix + "Recieved RunningSoftErrorDetected state notification");
+            logger.info(msgPrefix + "Received RunningSoftErrorDetected state notification");
 
             // do not touch degraded
             m_gemFM.setSoftErrorDetected(true);
@@ -1907,7 +1907,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
         String msgPrefix = "[GEM FM::" + m_gemFM.m_FMname + "] GEMEventHandler::runningAction(): ";
 
         if (obj instanceof StateEnteredEvent) {
-            logger.info(msgPrefix + "Recieved Running state notification");
+            logger.info(msgPrefix + "Received Running state notification");
 
             m_gemFM.setDegraded(false);
             m_gemFM.setSoftErrorDetected(false);

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
@@ -559,7 +559,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                 m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
                 logger.error(msgPrefix + msg, e);
             }
-                        
+
             // force TCDS HALTED
             if (m_gemFM.c_tcdsControllers != null) {
                 if (!m_gemFM.c_tcdsControllers.isEmpty()) {
@@ -844,7 +844,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         //m_gemFM.sendCMSError(msg);
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
-                    } 
+                    }
                 }
             }
 

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
@@ -71,7 +71,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
     GEMFunctionManager m_gemFM = null;
 
     /**
-     * <code>logger</code>: RCMS log4j logger.
+     * <code>logger</code>: RCMS log4j logger
      */
     static RCMSLogger logger = new RCMSLogger(GEMEventHandler.class);
 
@@ -192,8 +192,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
         String msgPrefix = "[GEM FM::" + m_gemFM.m_FMname + "] GEMEventHandler::checkRunInfoDBConnection(): ";
 
         if (m_gemFM.GEMRunInfo == null) {
-            logger.info(msgPrefix + "creating new RunInfo accessor with namespace: "
-                        + m_gemFM.GEM_NS + " now ...");
+            logger.info(msgPrefix + "creating new RunInfo accessor with namespace: " + m_gemFM.GEM_NS);
 
             //Get SID from parameter
             m_SID = ((IntegerT)m_gemPSet.get(GEMParameters.SID).getValue()).getInteger();
@@ -203,7 +202,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
             m_gemFM.GEMRunInfo = new RunInfo(ric,m_SID,Integer.valueOf(m_gemFM.RunNumber));
             m_gemFM.GEMRunInfo.setNameSpace(m_gemFM.GEM_NS);
 
-            logger.info(msgPrefix + "... RunInfo accessor available.");
+            logger.info(msgPrefix + "RunInfo accessor available.");
         }
     }
 
@@ -229,8 +228,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
             if (maxmoves < 30) { maxmoves = 30; }
             TheLine = "";
             theDice = new Random();
-            logger.debug(msgPrefix + "The GEMINI should show up - Look at it as it moves "
-                         + "through the sky");
+            logger.debug(msgPrefix + "The GEMINI should show up - Look at it as it moves through the sky");
         }
 
         public void movehim()
@@ -357,9 +355,9 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                 // globalConfKey = ((CommandParameter<StringT>)inputParSet.get(GEMParameters.GLOBAL_CONF_KEY)).getValue().toString();
             } catch (Exception e) {
                 // go to error, we require parameters
-                String msg = "initAction: error reading command parameters of Initialize command."
+                String msg = "error reading command parameters of Initialize command."
                     + e.getMessage();
-                logger.error(msg, e);
+                logger.error(msgPrefix + msg, e);
                 // notify error
                 sendCMSError(msg);
                 // go to error state
@@ -373,13 +371,13 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 
             List<QualifiedResource> qrList = m_gemQG.seekQualifiedResourcesOfType(new FunctionManager());
             for (QualifiedResource qr : qrList) {
-                logger.info(msgPrefix + " function manager resource found: " + qr.getName());
+                logger.info(msgPrefix + "function manager resource found: " + qr.getName());
                 availableResources.add(new StringT(qr.getName()));
             }
 
             qrList = m_gemQG.seekQualifiedResourcesOfType(new XdaqExecutive());
             for (QualifiedResource qr : qrList) {
-                logger.info(msgPrefix + " xdaq executive resource found: " + qr.getName());
+                logger.info(msgPrefix + "xdaq executive resource found: " + qr.getName());
                 availableResources.add(new StringT(qr.getName()));
                 // Snippet to get XDAQExecutive xml config
                 XdaqExecutive exec = (XdaqExecutive)qr;
@@ -397,7 +395,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
             qrList = m_gemQG.seekQualifiedResourcesOfType(new JobControl());
             // logger.info(msgPrefix + "Looking for job control resources");
             for (QualifiedResource qr : qrList) {
-                logger.info(msgPrefix + " job control resource found: " + qr.getName());
+                logger.info(msgPrefix + "job control resource found: " + qr.getName());
                 availableResources.add(new StringT(qr.getName()));
                 JobControl JC = (JobControl)qr;
                 // JC.executeCommand(); // BUG!!! executeCommand is not a function//
@@ -412,9 +410,9 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 
             qrList = m_gemQG.seekQualifiedResourcesOfType(new XdaqApplication());
             for (QualifiedResource qr : qrList) {
-                logger.info(msgPrefix + " xdaq application resource found: " + qr.getName());
+                logger.info(msgPrefix + "xdaq application resource found: " + qr.getName());
                 if (qr.getName().contains("Manager") || qr.getName().contains("Readout")) {
-                    qr.setActive(false);
+                    // qr.setActive(false);  // shouldn't be necessary if GEMSupervisor correctly handles the initialize case
                     continue;
                 }
                 availableResources.add(new StringT(qr.getName()));
@@ -428,13 +426,14 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                 logger.info(msgPrefix + "calling initXDAQ");
                 initXDAQ();
             } catch (UserActionException e) {
-                String msg = msgPrefix + "initAction: initXDAQ failed ";
-                m_gemFM.goToError(msg,e);
+                String msg = "initXDAQ failed ";
+                m_gemFM.goToError(msg, e);
                 // m_gemFM.sendCMSError(msg);  // when do this rather than goToError, or both?
                 m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
                 m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
-                logger.error(msg);
+                logger.error(msgPrefix + msg, e);
             }
+
             logger.info(msgPrefix + "initXDAQ finished");
 
             /************************************************
@@ -448,12 +447,12 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         logger.info(msgPrefix + "Trying to halt TCDS on initialize.");
                         m_gemFM.haltTCDSControllers();
                     } catch (UserActionException e) {
-                        String msg = msgPrefix + "initAction: ";
-                        m_gemFM.goToError(msg,e);
+                        String msg = "Caught exception";
+                        m_gemFM.goToError(msg, e);
                         // m_gemFM.sendCMSError(msg);  // when do this rather than goToError, or both?
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
-                        logger.error(msg);
+                        logger.error(msgPrefix + msg, e);
                     }
                 }
             }
@@ -465,12 +464,12 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         logger.info(msgPrefix + "Trying to initialize GEMSupervisor.");
                         m_gemFM.c_gemSupervisors.execute(GEMInputs.INITIALIZE);
                     } catch (QualifiedResourceContainerException e) {
-                        String msg = msgPrefix + "initAction: ";
-                        m_gemFM.goToError(msg,e);
+                        String msg = "Caught exception";
+                        m_gemFM.goToError(msg, e);
                         // m_gemFM.sendCMSError(msg);  // when do this rather than goToError, or both?
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",     new StringT("Error")));
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
-                        logger.error(msg,e);
+                        logger.error(msgPrefix + msg, e);
                     }
                 }
             }
@@ -482,12 +481,12 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         logger.info(msgPrefix + "Trying to halt uFEDKIT resources on initialize.");
                         m_gemFM.c_uFEDKIT.execute(GEMInputs.HALT);
                     } catch (QualifiedResourceContainerException e) {
-                        String msg = msgPrefix + "initAction: ";
-                        m_gemFM.goToError(msg,e);
+                        String msg = "Caught QualifiedResourceContainerException";
+                        m_gemFM.goToError(msg, e);
                         // m_gemFM.sendCMSError(msg);  // when do this rather than goToError, or both?
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",     new StringT("Error")));
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
-                        logger.error(msg);
+                        logger.error(msgPrefix + msg, e);
                     }
                 }
             }
@@ -546,6 +545,21 @@ public class GEMEventHandler extends UserStateNotificationHandler {
              * PUT YOUR CODE HERE
              ***********************************************/
 
+            m_gemFM.destroyXDAQ();
+
+            // initialize all XDAQ executives
+            try {
+                logger.info(msgPrefix + "calling initXDAQ");
+                initXDAQ();
+            } catch (UserActionException e) {
+                String msg = "initXDAQ failed ";
+                m_gemFM.goToError(msg, e);
+                // m_gemFM.sendCMSError(msg);  // when do this rather than goToError, or both?
+                m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
+                m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
+                logger.error(msgPrefix + msg, e);
+            }
+                        
             // force TCDS HALTED
             if (m_gemFM.c_tcdsControllers != null) {
                 if (!m_gemFM.c_tcdsControllers.isEmpty()) {
@@ -553,21 +567,32 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         logger.info(msgPrefix + "Trying to halt TCDS on reset.");
                         m_gemFM.haltTCDSControllers();
                     } catch (UserActionException e) {
-                        String errMsg = msgPrefix + "resetAction: " + e.getMessage();
-                        logger.warn(errMsg);
+                        String msg = "Caught UserActionException";
+                        logger.warn(msgPrefix + msg, e);
                     }
                 }
             }
 
-            // reset GEMFSMApplications
+            // reset GEMFSMApplications and then send INITIALIZE
             if (m_gemFM.c_gemSupervisors != null) {
                 if (!m_gemFM.c_gemSupervisors.isEmpty()) {
                     try {
-                        logger.info(msgPrefix + "Trying to reset GEMSupervisor.");
+                        logger.info(msgPrefix + "Trying to reset GEMSupervisor");
                         m_gemFM.c_gemSupervisors.execute(GEMInputs.RESET);
                     } catch (QualifiedResourceContainerException e) {
-                        String errMsg = msgPrefix + "resetAction: " + e.getMessage();
-                        logger.warn(errMsg);
+                        String msg = "Caught QualifiedResourceContainerException";
+                        logger.warn(msgPrefix + msg, e);
+                    }
+
+                    // need to now initialize GEM resoureces as RESET puts them into INITIAL state,
+                    // but RCMS puts things into HALTED state
+
+                    try {
+                        logger.info(msgPrefix + "Trying to initialize GEMSupervisor");
+                        m_gemFM.c_gemSupervisors.execute(GEMInputs.INITIALIZE);
+                    } catch (QualifiedResourceContainerException e) {
+                        String msg = "Caught QualifiedResourceContainerException";
+                        logger.warn(msgPrefix + msg, e);
                     }
                 }
             }
@@ -579,8 +604,8 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         logger.info(msgPrefix + "Trying to halt uFEDKIT resources on reset.");
                         m_gemFM.c_uFEDKIT.execute(GEMInputs.HALT);
                     } catch (QualifiedResourceContainerException e) {
-                        String errMsg = msgPrefix + "resetAction: " + e.getMessage();
-                        logger.warn(errMsg);
+                        String msg = "Caught QualifiedResourceContainerException";
+                        logger.warn(msgPrefix + msg, e);
                     }
                 }
             }
@@ -717,10 +742,9 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                 }
             } catch (Exception e) {
                 // go to error, we require parameters
-                String errMsg = "configureAction: error reading command parameters of Configure command."
-                    + e.getMessage();
-                logger.error(errMsg, e);
-                sendCMSError(errMsg);
+                String msg = "error reading command parameters of Configure command.";
+                logger.error(msgPrefix + msg, e);
+                sendCMSError(msg);
                 //go to error state
                 m_gemFM.fireEvent( GEMInputs.SETERROR );
                 return;
@@ -748,11 +772,11 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         logger.info(msgPrefix + "Trying to configure TCDS on configure.");
                         m_gemFM.configureTCDSControllers();
                     } catch (UserActionException e) {
-                        String errMsg = msgPrefix + "configureAction: " + e.getMessage();
-                        logger.error(errMsg);
+                        String msg = "Caught UserActionException";
+                        logger.error(msgPrefix + msg, e);
                         //m_gemFM.sendCMSError(msg);
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
-                        m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(errMsg)));
+                        m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
                     }
                 }
             }
@@ -764,11 +788,11 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         logger.info(msgPrefix + "Trying to configure GEMSupervisor.");
                         m_gemFM.c_gemSupervisors.execute(GEMInputs.CONFIGURE);
                     } catch (QualifiedResourceContainerException e) {
-                        String errMsg = msgPrefix + "configureAction: " + e.getMessage();
-                        logger.error(errMsg);
+                        String msg = "Caught QualifiedResourceContainerException";
+                        logger.error(msgPrefix + msg, e);
                         //m_gemFM.sendCMSError(msg);
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
-                        m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(errMsg)));
+                        m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
                     }
                 }
             }
@@ -783,11 +807,11 @@ public class GEMEventHandler extends UserStateNotificationHandler {
               logger.info(msgPrefix + "Trying to configure uFEDKIT resources on configure.");
               m_gemFM.c_uFEDKIT.execute(GEMInputs.CONFIGURE);
               } catch (QualifiedResourceContainerException e) {
-              String errMsg = msgPrefix + "configureAction: " + e.getMessage();
-              logger.error(errMsg);
+              String msg = "Caught QualifiedResourceContainerException";
+              logger.error(msgPrefix + msg, e);
               //m_gemFM.sendCMSError(msg);
               m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
-              m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(errMsg)));
+              m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
               }
               }
               }
@@ -800,11 +824,11 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         logger.info(msgPrefix + "Trying to configure EVM resources on configure.");
                         m_gemFM.c_EVMs.execute(GEMInputs.CONFIGURE);
                     } catch (QualifiedResourceContainerException e) {
-                        String errMsg = msgPrefix + "configureAction: " + e.getMessage();
-                        logger.error(errMsg);
+                        String msg = "Caught QualifiedResourceContainerException";
+                        logger.error(msgPrefix + msg, e);
                         //m_gemFM.sendCMSError(msg);
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
-                        m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(errMsg)));
+                        m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
                     }
                 }
             }
@@ -815,12 +839,12 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         logger.info(msgPrefix + "Trying to configure BU resources on configure.");
                         m_gemFM.c_BUs.execute(GEMInputs.CONFIGURE);
                     } catch (QualifiedResourceContainerException e) {
-                        String errMsg = msgPrefix + "configureAction: " + e.getMessage();
-                        logger.error(errMsg);
+                        String msg = "Caught QualifiedResourceContainerException";
+                        logger.error(msgPrefix + msg, e);
                         //m_gemFM.sendCMSError(msg);
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
-                        m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(errMsg)));
-                    }
+                        m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
+                    } 
                 }
             }
 
@@ -830,11 +854,11 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         logger.info(msgPrefix + "Trying to configure Ferol resources on configure.");
                         m_gemFM.c_Ferols.execute(GEMInputs.CONFIGURE);
                     } catch (QualifiedResourceContainerException e) {
-                        String errMsg = msgPrefix + "configureAction: " + e.getMessage();
-                        logger.error(errMsg);
+                        String msg = "Caught QualifiedResourceContainerException";
+                        logger.error(msgPrefix + msg, e);
                         //m_gemFM.sendCMSError(msg);
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
-                        m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(errMsg)));
+                        m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
                     }
                 }
             }
@@ -902,10 +926,10 @@ public class GEMEventHandler extends UserStateNotificationHandler {
             /*if (inputParSet.size()==0 || inputParSet.get(GEMParameters.RUN_NUMBER) == null )  {
 
             // go to error, we require parameters
-            String errMsg = "startAction: no parameters given with start command.";
+            String errMsg = "no parameters given with start command.";
 
             // log error
-            logger.error(errMsg);
+            logger.error(msgPrefix + errMsg, e);
 
             // notify error
             sendCMSError(errMsg);
@@ -959,12 +983,12 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                             String msg = "Error! XDAQTimeoutException when "
                                 + " trying to send the m_gemFM.RunNumber to the GEM supervisor\n Perhaps this "
                                 + "application is dead!?";
-                            m_gemFM.goToError(msg,e);
+                            m_gemFM.goToError(msg, e);
                             logger.error(msgPrefix + msg);
                         } catch (XDAQException e) {
                             String msg = "Error! XDAQException when trying "
                                 + "to send the m_gemFM.RunNumber to the GEM supervisor";
-                            m_gemFM.goToError(msg,e);
+                            m_gemFM.goToError(msg, e);
                             logger.error(msgPrefix + msg);
                         }
                     }
@@ -973,8 +997,8 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         logger.info(msgPrefix + "Trying to start GEMSupervisor.");
                         m_gemFM.c_gemSupervisors.execute(GEMInputs.START);
                     } catch (QualifiedResourceContainerException e) {
-                        String msg = msgPrefix + e.getMessage();
-                        logger.error(msg);
+                        String msg = "Caught QualifiedResourceContainerException";
+                        logger.error(msgPrefix + msg, e);
                         //m_gemFM.sendCMSError(msg);
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
@@ -991,9 +1015,9 @@ public class GEMEventHandler extends UserStateNotificationHandler {
               logger.info(msgPrefix + "Trying to enable uFEDKIT resources on start.");
               m_gemFM.c_uFEDKIT.execute(GEMInputs.ENABLE);
               } catch (QualifiedResourceContainerException e) {
-              String msg = msgPrefix + "startAction: " + e.getMessage();
-              logger.error(msg);
-              m_gemFM.goToError(msg,e);
+              String msg = "Caught QualifiedResourceContainerException";
+              logger.error(msgPrefix + msg, e);
+              m_gemFM.goToError(msg, e);
               // m_gemFM.sendCMSError(msg);  // when do this rather than goToError, or both?
               m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
               m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
@@ -1004,30 +1028,80 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 
             if (m_gemFM.c_EVMs != null) {
                 if (!m_gemFM.c_EVMs.isEmpty()) {
+                    XDAQParameter pam = null;
+                    // prepare and set the runNumber for all EVMs
+                    for (QualifiedResource qr : m_gemFM.c_EVMs.getApplications() ){
+                        try {
+                            pam = ((XdaqApplication)qr).getXDAQParameter();
+                            pam.select(new String[] {"runNumber"});
+                            pam.get();
+                            String evmRunNumber = pam.getValue("RunNumber");
+                            logger.info(msgPrefix + "Obtained run number from evm: " + evmRunNumber);
+                            pam.setValue("runNumber",m_gemFM.RunNumber.toString());
+                            pam.send();
+                        } catch (XDAQTimeoutException e) {
+                            String msg = "Error! XDAQTimeoutException: startAction() when "
+                                + " trying to send the m_gemFM.RunNumber to the GEM supervisor\n Perhaps this "
+                                + "application is dead!?";
+                            m_gemFM.goToError(msg, e);
+                            logger.error(msgPrefix + msg);
+                        } catch (XDAQException e) {
+                            String msg = "Error! XDAQException: startAction() when trying "
+                                + "to send the m_gemFM.RunNumber to the GEM supervisor";
+                            m_gemFM.goToError(msg, e);
+                            logger.error(msgPrefix + msg);
+                        }
+                    }
+
                     try {
                         logger.info(msgPrefix + "Trying to enable EVM resources on start.");
                         m_gemFM.c_EVMs.execute(GEMInputs.ENABLE);
                     } catch (QualifiedResourceContainerException e) {
-                        String errMsg = msgPrefix + e.getMessage();
-                        logger.error(errMsg);
+                        String msg = "Caught QualifiedResourceContainerException";
+                        logger.error(msgPrefix + msg, e);
                         //m_gemFM.sendCMSError(msg);
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
-                        m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(errMsg)));
+                        m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
                     }
                 }
             }
 
             if (m_gemFM.c_BUs != null) {
                 if (!m_gemFM.c_BUs.isEmpty()) {
+                    XDAQParameter pam = null;
+                    // prepare and set the runNumber for all BUs
+                    for (QualifiedResource qr : m_gemFM.c_BUs.getApplications() ){
+                        try {
+                            pam = ((XdaqApplication)qr).getXDAQParameter();
+                            pam.select(new String[] {"runNumber"});
+                            pam.get();
+                            String buRunNumber = pam.getValue("RunNumber");
+                            logger.info(msgPrefix + "Obtained run number from bu: " + buRunNumber);
+                            pam.setValue("runNumber",m_gemFM.RunNumber.toString());
+                            pam.send();
+                        } catch (XDAQTimeoutException e) {
+                            String msg = "Error! XDAQTimeoutException: startAction() when "
+                                + " trying to send the m_gemFM.RunNumber to the GEM supervisor\n Perhaps this "
+                                + "application is dead!?";
+                            m_gemFM.goToError(msg, e);
+                            logger.error(msgPrefix + msg);
+                        } catch (XDAQException e) {
+                            String msg = "Error! XDAQException: startAction() when trying "
+                                + "to send the m_gemFM.RunNumber to the GEM supervisor";
+                            m_gemFM.goToError(msg, e);
+                            logger.error(msgPrefix + msg);
+                        }
+                    }
+
                     try {
                         logger.info(msgPrefix + "Trying to enable BU resources on start.");
                         m_gemFM.c_BUs.execute(GEMInputs.ENABLE);
                     } catch (QualifiedResourceContainerException e) {
-                        String errMsg = msgPrefix + e.getMessage();
-                        logger.error(errMsg);
+                        String msg = "Caught QualifiedResourceContainerException";
+                        logger.error(msgPrefix + msg, e);
                         //m_gemFM.sendCMSError(msg);
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
-                        m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(errMsg)));
+                        m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
                     }
                 }
             }
@@ -1038,11 +1112,11 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         logger.info(msgPrefix + "Trying to enable Ferol resources on start.");
                         m_gemFM.c_Ferols.execute(GEMInputs.ENABLE);
                     } catch (QualifiedResourceContainerException e) {
-                        String errMsg = msgPrefix + e.getMessage();
-                        logger.error(errMsg);
+                        String msg = "Caught QualifiedResourceContainerException";
+                        logger.error(msgPrefix + msg, e);
                         //m_gemFM.sendCMSError(msg);
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
-                        m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(errMsg)));
+                        m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
                     }
                 }
             }
@@ -1054,9 +1128,9 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         logger.info(msgPrefix + "Trying to enable TCDS resources on start.");
                         m_gemFM.enableTCDSControllers();
                     } catch (UserActionException e) {
-                        String msg = msgPrefix + e.getMessage();
-                        logger.error(msg);
-                        m_gemFM.goToError(msg,e);
+                        String msg = "Caught UserActionException";
+                        logger.error(msgPrefix + msg, e);
+                        m_gemFM.goToError(msg, e);
                         // m_gemFM.sendCMSError(msg);  // when do this rather than goToError, or both?
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
@@ -1115,12 +1189,12 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         logger.info(msgPrefix + "Trying to pause TCDS on pause.");
                         m_gemFM.pauseTCDSControllers();
                     } catch (UserActionException e) {
-                        String msg = msgPrefix + "pauseAction: " + e.getMessage();
-                        m_gemFM.goToError(msg,e);
+                        String msg = "Caught UserActionException";
+                        m_gemFM.goToError(msg, e);
                         // m_gemFM.sendCMSError(msg);  // when do this rather than goToError, or both?
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
-                        logger.error(msg);
+                        logger.error(msgPrefix + msg, e);
                     }
                 }
             }
@@ -1132,12 +1206,12 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         logger.info(msgPrefix + "Trying to pause GEMSupervisor.");
                         m_gemFM.c_gemSupervisors.execute(GEMInputs.PAUSE);
                     } catch (QualifiedResourceContainerException e) {
-                        String msg = msgPrefix + "pauseAction: " + e.getMessage();
-                        m_gemFM.goToError(msg,e);
+                        String msg = "Caught QualifiedResourceContainerException";
+                        m_gemFM.goToError(msg, e);
                         // m_gemFM.sendCMSError(msg);  // when do this rather than goToError, or both?
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
-                        logger.error(msg);
+                        logger.error(msgPrefix + msg, e);
                     }
                 }
             }
@@ -1150,12 +1224,12 @@ public class GEMEventHandler extends UserStateNotificationHandler {
             logger.info(msgPrefix + "Trying to pause uFEDKIT resources on pause.");
             m_gemFM.c_uFEDKIT.execute(GEMInputs.PAUSE);
             } catch (QualifiedResourceContainerException e) {
-            String msg = msgPrefix + "pauseAction: " + e.getMessage();
-            m_gemFM.goToError(msg,e);
+            String msg = "Caught QualifiedResourceContainerException";
+            m_gemFM.goToError(msg, e);
             // m_gemFM.sendCMSError(msg);  // when do this rather than goToError, or both?
             m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
             m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
-            logger.error(msg);
+            logger.error(msgPrefix + msg, e);
             }
             }
             }
@@ -1211,12 +1285,12 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         logger.info(msgPrefix + "Trying to stop TCDS on stop.");
                         m_gemFM.stopTCDSControllers();
                     } catch (UserActionException e) {
-                        String msg = msgPrefix + "stopAction: " + e.getMessage();
-                        m_gemFM.goToError(msg,e);
+                        String msg = "Caught UserActionException";
+                        m_gemFM.goToError(msg, e);
                         // m_gemFM.sendCMSError(msg);  // when do this rather than goToError, or both?
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
-                        logger.error(msg);
+                        logger.error(msgPrefix + msg, e);
                     }
                 }
             }
@@ -1228,12 +1302,12 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         logger.info(msgPrefix + "Trying to stop GEMSupervisor.");
                         m_gemFM.c_gemSupervisors.execute(GEMInputs.STOP);
                     } catch (QualifiedResourceContainerException e) {
-                        String msg = msgPrefix + "stopAction: " + e.getMessage();
-                        m_gemFM.goToError(msg,e);
+                        String msg = "Caught QualifiedResourceContainerException";
+                        m_gemFM.goToError(msg, e);
                         // m_gemFM.sendCMSError(msg);  // when do this rather than goToError, or both?
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
-                        logger.error(msg);
+                        logger.error(msgPrefix + msg, e);
                     }
                 }
             }
@@ -1247,12 +1321,12 @@ public class GEMEventHandler extends UserStateNotificationHandler {
               logger.info(msgPrefix + "Trying to stop uFEDKIT resources on stop.");
               m_gemFM.c_uFEDKIT.execute(GEMInputs.STOP);
               } catch (QualifiedResourceContainerException e) {
-              String msg = msgPrefix + "stopAction: " + e.getMessage();
-              m_gemFM.goToError(msg,e);
+              String msg = "Caught QualifiedResourceContainerException";
+              m_gemFM.goToError(msg, e);
               // m_gemFM.sendCMSError(msg);  // when do this rather than goToError, or both?
               m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
               m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
-              logger.error(msg);
+              logger.error(msgPrefix + msg, e);
               }
               }
               }
@@ -1264,11 +1338,11 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         logger.info(msgPrefix + "Trying to stop EVM resources on stop.");
                         m_gemFM.c_EVMs.execute(GEMInputs.STOP);
                     } catch (QualifiedResourceContainerException e) {
-                        String errMsg = msgPrefix + "stopAction: " + e.getMessage();
-                        logger.error(errMsg);
+                        String msg = "Caught QualifiedResourceContainerException";
+                        logger.error(msgPrefix + msg, e);
                         //m_gemFM.sendCMSError(msg);
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
-                        m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(errMsg)));
+                        m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
                     }
                 }
             }
@@ -1279,11 +1353,11 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         logger.info(msgPrefix + "Trying to stop BU resources on stop.");
                         m_gemFM.c_BUs.execute(GEMInputs.STOP);
                     } catch (QualifiedResourceContainerException e) {
-                        String errMsg = msgPrefix + "stopAction: " + e.getMessage();
-                        logger.error(errMsg);
+                        String msg = "Caught QualifiedResourceContainerException";
+                        logger.error(msgPrefix + msg, e);
                         //m_gemFM.sendCMSError(msg);
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
-                        m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(errMsg)));
+                        m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
                     }
                 }
             }
@@ -1294,11 +1368,11 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         logger.info(msgPrefix + "Trying to stop Ferol resources on stop.");
                         m_gemFM.c_Ferols.execute(GEMInputs.STOP);
                     } catch (QualifiedResourceContainerException e) {
-                        String errMsg = msgPrefix + "stopAction: " + e.getMessage();
-                        logger.error(errMsg);
+                        String msg = "Caught QualifiedResourceContainerException";
+                        logger.error(msgPrefix + msg, e);
                         //m_gemFM.sendCMSError(msg);
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
-                        m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(errMsg)));
+                        m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
                     }
                 }
             }
@@ -1354,18 +1428,21 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         try {
                             pam = ((XdaqApplication)qr).getXDAQParameter();
                             pam.select(new String[] {"RunNumber"});
+                            pam.get();
+                            String superRunNumber = pam.getValue("RunNumber");
+                            logger.info(msgPrefix + "Obtained run number from supervisor: " + superRunNumber);
                             pam.setValue("RunNumber",m_gemFM.RunNumber.toString());
                             pam.send();
                         } catch (XDAQTimeoutException e) {
                             String msg = "Error! XDAQTimeoutException: startAction() when "
                                 + " trying to send the m_gemFM.RunNumber to the GEM supervisor\n Perhaps this "
                                 + "application is dead!?";
-                            m_gemFM.goToError(msg,e);
+                            m_gemFM.goToError(msg, e);
                             logger.error(msgPrefix + msg);
                         } catch (XDAQException e) {
                             String msg = "Error! XDAQException: startAction() when trying "
                                 + "to send the m_gemFM.RunNumber to the GEM supervisor";
-                            m_gemFM.goToError(msg,e);
+                            m_gemFM.goToError(msg, e);
                             logger.error(msgPrefix + msg);
                         }
                     }
@@ -1392,9 +1469,9 @@ public class GEMEventHandler extends UserStateNotificationHandler {
             logger.info(msgPrefix + "Trying to enable uFEDKIT resources on start.");
             m_gemFM.c_uFEDKIT.execute(GEMInputs.ENABLE);
             } catch (QualifiedResourceContainerException e) {
-            String msg = msgPrefix + e.getMessage();
-            logger.error(msg);
-            m_gemFM.goToError(msg,e);
+            String msg = "Caught QualifiedResourceContainerException";
+            logger.error(msgPrefix + msg, e);
+            m_gemFM.goToError(msg, e);
             // m_gemFM.sendCMSError(msg);  // when do this rather than goToError, or both?
             m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
             m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
@@ -1412,7 +1489,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                     } catch (UserActionException e) {
                         String msg = e.getMessage();
                         logger.error(msgPrefix + msg);
-                        m_gemFM.goToError(msg,e);
+                        m_gemFM.goToError(msg, e);
                         // m_gemFM.sendCMSError(msg);  // when do this rather than goToError, or both?
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
@@ -1477,7 +1554,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         m_gemFM.haltTCDSControllers();
                     } catch (UserActionException e) {
                         String msg = e.getMessage();
-                        m_gemFM.goToError(msg,e);
+                        m_gemFM.goToError(msg, e);
                         // m_gemFM.sendCMSError(msg);  // when do this rather than goToError, or both?
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
@@ -1494,7 +1571,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         m_gemFM.c_gemSupervisors.execute(GEMInputs.HALT);
                     } catch (QualifiedResourceContainerException e) {
                         String msg = e.getMessage();
-                        m_gemFM.goToError(msg,e);
+                        m_gemFM.goToError(msg, e);
                         // m_gemFM.sendCMSError(msg);  // when do this rather than goToError, or both?
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
@@ -1511,7 +1588,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                         m_gemFM.c_uFEDKIT.execute(GEMInputs.HALT);
                     } catch (QualifiedResourceContainerException e) {
                         String msg = e.getMessage();
-                        m_gemFM.goToError(msg,e);
+                        m_gemFM.goToError(msg, e);
                         // m_gemFM.sendCMSError(msg);  // when do this rather than goToError, or both?
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
                         m_gemPSet.put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
@@ -1622,15 +1699,14 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                 ((StringT)inputParSet.get(GEMParameters.TTS_TEST_PATTERN).getValue()).equals("") ||
                 inputParSet.get(GEMParameters.TTS_TEST_SEQUENCE_REPEAT) == null)
                 {
-
                     // go to error, we require parameters
-                    String errMsg = "testingTTSAction: no parameters given with TestTTS command.";
+                    String msg = "testingTTSAction: no parameters given with TestTTS command.";
 
                     // log error
-                    logger.error(errMsg);
+                    logger.error(msg);
 
                     // notify error
-                    sendCMSError(errMsg);
+                    sendCMSError(msg);
 
                     //go to error state
                     m_gemFM.fireEvent( GEMInputs.SETERROR );
@@ -1841,7 +1917,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
         }
     }
 
-
+    // This is duplicated from GEMFunctionManger --- why?
     @SuppressWarnings("unchecked")
 	private void sendCMSError(String errMessage)
     {
@@ -1859,7 +1935,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
         try {
             m_gemFM.getParentErrorNotifier().sendError(error);
         } catch (Exception e) {
-            logger.warn(m_gemFM.getClass().toString() + ": Failed to send error mesage " + errMessage);
+            logger.warn(msgPrefix + "Failed to send error mesage " + errMessage);
         }
     }
 
@@ -1883,8 +1959,8 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 
         // Look if the configuration uses TCDS and handle accordingly.
         // First check if TCDS is being used, and if so, tell RCMS that the TCDS executives are already initialized.
-        String msg = msgPrefix + "Initializing XDAQ applications...";
-        logger.info(msg);
+        String msg = "Initializing XDAQ applications...";
+        logger.info(msgPrefix + msg);
         Boolean usingTCDS = false;
         // QualifiedGroup qg = m_gemFM.getQualifiedGroup();
 
@@ -1908,9 +1984,8 @@ public class GEMEventHandler extends UserStateNotificationHandler {
             // TODO This needs to be moved out into userXML or a snippet!!!
             if (hostName.contains("tcds")) {
                 usingTCDS = true;
-                msg = msgPrefix + "initXDAQ() -- the TCDS executive on hostName "
-                    + hostName + " is being handled in a special way.";
-                logger.info(msg);
+                msg = "the TCDS executive on hostName " + hostName + " is being handled in a special way.";
+                logger.info(msgPrefix + msg);
                 qr.setInitialized(true);
             }
         }
@@ -1921,9 +1996,9 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 
         for (QualifiedResource qr: jcList) {
             if (qr.getResource().getHostName().contains("tcds")) {
-                msg = msgPrefix + "Masking the  application with name "
-                    + qr.getName() + " running on host " + qr.getResource().getHostName();
-                logger.info(msg);
+                msg = "Masking the  application with name " + qr.getName()
+                    + " running on host " + qr.getResource().getHostName();
+                logger.info(msgPrefix + msg);
                 qr.setActive(false);
             }
         }
@@ -1947,8 +2022,8 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 
         List<String> applicationClasses = m_gemFM.c_xdaqServiceApps.getApplicationClasses();
         for (String cla : applicationClasses) {
-            msg = msgPrefix + "found service application class: " + cla;
-            logger.info(msg);
+            msg = "found service application class: " + cla;
+            logger.info(msgPrefix + msg);
         }
 
         // TCDS apps -> Needs to be defined for GEM
@@ -1979,22 +2054,21 @@ public class GEMEventHandler extends UserStateNotificationHandler {
         // Now if we are using TCDS, give all of the TCDS applications the URN that they need.
 
         try {
-            msg = msgPrefix + "initializing the qualified group and printing the qualifed group\n";
-            logger.info(msg + m_gemQG.print());
+            msg = "initializing the qualified group and printing the qualifed group\n";
+            logger.info(msgPrefix + msg + m_gemQG.print());
             m_gemQG.init();
         } catch (Exception e) {
             // failed to init
             StringWriter sw = new StringWriter();
             e.printStackTrace( new PrintWriter(sw) );
             System.out.println(sw.toString());
-            msg = msgPrefix + "" + this.getClass().toString() +
-                " failed to initialize resources. Printing stacktrace: "+ sw.toString();
-            logger.error(msg);
+            msg = this.getClass().toString() + " failed to initialize resources. Printing stacktrace: " + sw.toString();
+            logger.error(msgPrefix + msg, e);
             throw new UserActionException(e.getMessage());
         }
 
-        msg = msgPrefix + "initialized the qualified group";
-        logger.info(msg);
+        msg = "initialized the qualified group";
+        logger.info(msgPrefix + msg);
 
         // Now, find xdaq applications
         List<QualifiedResource> xdaqAppList = m_gemQG.seekQualifiedResourcesOfType(new XdaqApplication());
@@ -2002,13 +2076,13 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 
         applicationClasses = m_gemFM.c_xdaqApps.getApplicationClasses();
         for (String cla : applicationClasses) {
-            msg = msgPrefix + "found application class: " + cla;
-            logger.info(msg);
+            msg = "found application class: " + cla;
+            logger.info(msgPrefix + msg);
         }
 
-        msg = msgPrefix + "" + xdaqAppList.size() + " XDAQ applications controlled, "
+        msg = xdaqAppList.size() + " XDAQ applications controlled, "
             + xdaqServiceAppList.size() + " XDAQ service applications used";
-        logger.debug(msg);
+        logger.debug(msgPrefix + msg);
 
         // fill applications
         msg = "Retrieving GEM XDAQ applications ...";
@@ -2057,43 +2131,42 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 
             String dowehaveanasyncgemSupervisor = "undefined";
 
-            logger.info(msgPrefix + "initXDAQ: looping over qualified resources of GEMSupervisor type");
+            logger.info(msgPrefix + "looping over qualified resources of GEMSupervisor type");
             // ask for the status of the GEM supervisor and wait until it is Ready or Failed
             for (QualifiedResource qr : m_gemFM.c_gemSupervisors.getApplications() ){
-                logger.info(msgPrefix + "initXDAQ: found qualified resource of GEMSupervisor type");
+                logger.info(msgPrefix + "found qualified resource of GEMSupervisor type");
                 try {
-                    logger.info(msgPrefix + "initXDAQ: trying to get parameters");
+                    logger.info(msgPrefix + "trying to get parameters");
                     pam =((XdaqApplication)qr).getXDAQParameter();
-                    logger.info(msgPrefix + "initXDAQ: got parameters, selecting:");
+                    logger.info(msgPrefix + "got parameters, selecting:");
 
                     pam.select(new String[] {"TriggerAdapterName", "PartitionState", "InitializationProgress","ReportStateToRCMS"});
-                    logger.info(msgPrefix + "initXDAQ: parameters selected, getting:");
+                    logger.info(msgPrefix + "parameters selected, getting:");
                     pam.get();
-                    logger.info(msgPrefix + "initXDAQ: got selectedparameters!");
+                    logger.info(msgPrefix + "got selectedparameters!");
 
                     dowehaveanasyncgemSupervisor = pam.getValue("ReportStateToRCMS");
-                    msg = msgPrefix + "initXDAQ(): asking for the GEM supervisor "
-                        + "ReportStateToRCMS results is: " + dowehaveanasyncgemSupervisor;
-                    logger.info(msg);
+                    msg = "asking for the GEM supervisor ReportStateToRCMS results is: " + dowehaveanasyncgemSupervisor;
+                    logger.info(msgPrefix + msg);
 
                 } catch (XDAQTimeoutException e) {
-                    msg = msgPrefix + "Error! XDAQTimeoutException in initXDAQ() when checking "
-                        + "the async SOAP capabilities ...\n Perhaps the GEMSupervisor application is dead!?";
-                    //m_gemFM.goToError(msg,e);
-                    logger.error(msg);
+                    msg = "Error! XDAQTimeoutException in initXDAQ() when checking the async SOAP capabilities\n"
+                        + "Perhaps the GEMSupervisor application is dead!?";
+                    //m_gemFM.goToError(msg, e);
+                    logger.error(msgPrefix + msg, e);
                 } catch (XDAQException e) {
-                    msg = msgPrefix + "Error! XDAQException in initXDAQ() when checking the async "
-                        + "SOAP capabilities ...";
-                    //m_gemFM.goToError(msg,e);
-                    logger.error(msg);
+                    msg = "Error! XDAQException in initXDAQ() when checking the async SOAP capabilities";
+                    //m_gemFM.goToError(msg, e);
+                    logger.error(msgPrefix + msg, e);
                 }
 
                 logger.info(msgPrefix + "using async SOAP communication with GEMSupervisor ...");
             }
         } else {
-            msg = msgPrefix + "Warning! No GEM supervisor found in initXDAQ()."
-                +"\nThis happened when checking the async SOAP capabilities.\nThis is OK for a level1 FM.";
-            logger.info(msg);
+            msg = "Warning! No GEM supervisor found in initXDAQ().\n"
+                + "This happened when checking the async SOAP capabilities.\n"
+                + "This is OK for a level1 FM.";
+            logger.warn(msgPrefix + msg);
         }
         /*
         // finally, halt all LPM apps

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMFunctionManager.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMFunctionManager.java
@@ -410,11 +410,11 @@ public class GEMFunctionManager extends UserFunctionManager {
             try {
                 logger.debug(msgPrefix + "Trying to close log sessionId = " + sessionId );
                 logSessionConnector.closeSession(sessionId);
-                logger.debug(msgPrefix + "... closed log sessionId = " + sessionId );
-            } catch (LogSessionException e1) {
+                logger.debug(msgPrefix + "Closed log sessionId = " + sessionId );
+            } catch (LogSessionException e) {
                 logger.warn(msgPrefix + "Could not close sessionId, but sessionId was requested and used.\n"
                             + "This is OK only for global runs.\n"
-                            + "Exception: ", e1);
+                            + "Exception: ", e);
             }
         } else {
             logger.warn("[GEM base] logSessionConnector null");

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMFunctionManager.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMFunctionManager.java
@@ -246,11 +246,11 @@ public class GEMFunctionManager extends UserFunctionManager {
             String rcmsStateListenerProtocol = fmURL.getProtocol();
             m_rcmsStateListenerURL = rcmsStateListenerProtocol+"://"+rcmsStateListenerHost+":"+rcmsStateListenerPort+"/rcms";
         } catch (MalformedURLException e) {
-            String errMsg = msgPrefix + "Error! MalformedURLException in createAction" + e.getMessage();
-            logger.error(errMsg,e);
-            sendCMSError(errMsg);
+            String msg = "Caught MalformedURLException";
+            logger.error(msgPrefix + msg, e);
+            sendCMSError(msg);
             getParameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
-            getParameterSet().put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(errMsg)));
+            getParameterSet().put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
             // if (theEventHandler.TestMode.equals("off")) { firePriorityEvent(GEMInputs.SETERROR); ErrorState = true; return;}
         }
 
@@ -307,9 +307,9 @@ public class GEMFunctionManager extends UserFunctionManager {
                     logger.info(msgPrefix + "Trying to halt TCDS on destroy.");
                     haltTCDSControllers();
                 } catch (UserActionException e) {
-                    String msg = msgPrefix + "destroyAction: got an exception while halting TCDS";
-                    logger.error(msg + ": " + e);
-                    goToError(msg,e);
+                    String msg = "got an exception while halting TCDS";
+                    logger.error(msgPrefix + msg, e);
+                    goToError(msg, e);
                 }
             }
         }
@@ -319,8 +319,8 @@ public class GEMFunctionManager extends UserFunctionManager {
         //     throw e;
         // }
 
-        String msg = msgPrefix + "destroyAction: destroying the Qualified Group";
-        logger.info(msg);
+        String msg = "destroying the Qualified Group";
+        logger.info(msgPrefix + msg);
         this.getQualifiedGroup().destroy();
 
         System.out.println(msgPrefix + "destroyAction executed");
@@ -489,7 +489,7 @@ public class GEMFunctionManager extends UserFunctionManager {
     public void goToError(String errMessage, Exception e)
     {
         String msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::goToError(String, Exception): ";
-        errMessage += " Message from the caught exception is: "+e.getMessage();
+        errMessage+= ": Message from the caught exception is: " + e.getMessage();
         goToError(errMessage);
     }
 
@@ -500,7 +500,6 @@ public class GEMFunctionManager extends UserFunctionManager {
     {
         String msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::goToError(String): ";
 
-        logger.error(msgPrefix + "" + errMessage);
         sendCMSError(errMessage);
         getParameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
         getParameterSet().put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(errMessage)));
@@ -794,99 +793,92 @@ public class GEMFunctionManager extends UserFunctionManager {
         logger.info(msgPrefix + "destroyXDAQ called");
 	// QualifiedGroup qg = getQualifiedGroup();
 
+        /* ** THIS CAUSES FAILURE, POSSIBLY DUE TO FWK BUG WITH LIGHT CONFIGS **
 	// see if there is an exec with a supervisor and kill it first
 	URI supervExecURI = null;
 	if (c_gemSupervisors != null) {
             if (!c_gemSupervisors.isEmpty()) {
-                logger.info(msgPrefix + "destroyXDAQ: killing GEMSupervisor executives ("
-                            + c_gemSupervisors.getApplications().size() + ")");
+                logger.info(msgPrefix + "killing GEMSupervisor executives (" + c_gemSupervisors.getApplications().size() + ")");
                 for (QualifiedResource qr : c_gemSupervisors.getApplications()) {
+                    // seems to not require the looping
                     // Resource supervResource = c_gemSupervisors.getApplications().get(0).getResource();
-                    logger.info(msgPrefix + "destroyXDAQ: killing executive for supervisor process "
-                                + qr.getName());
+                    logger.info(msgPrefix + "killing executive for supervisor process " + qr.getName());
                     Resource supervResource = qr.getResource();
-                    logger.info(msgPrefix + "destroyXDAQ: got supervisor resource " + qr.getName());
-                    XdaqExecutiveResource qrSupervParentExec =
-                        ((XdaqApplicationResource)supervResource).getXdaqExecutiveResourceParent();
-                    logger.info(msgPrefix + "destroyXDAQ: got supervisor executive "
-                                + qrSupervParentExec.getApplicationClassName());
-                    supervExecURI = qrSupervParentExec.getURI();
-                    QualifiedResource qrExec = m_gemQG.seekQualifiedResourceOfURI(supervExecURI);
-                    XdaqExecutive     ex     = (XdaqExecutive) qrExec;
-                    logger.info(msgPrefix + "destroyXDAQ: killing supervisor executive with URI "
-                                + supervExecURI.toString()
-                                + ", executive initialized: " + ex.isInitialized());
+                    logger.info(msgPrefix + "got supervisor resource " + qr.getName());
                     try {
-                        logger.info(msgPrefix + "destroyXDAQ: killing supervisor executive " + ex.getName());
-                        // ex.destroy();
-                        ex.killMe();
-                    } catch ( Exception e) {
-                        String msg = "[GEM "+m_FMname+"] destroyXDAQ: Exception when destroying supervisor executive named:"
-                            + ex.getName()
-                            + " with URI " + ex.getURI().toString();
-                        logger.error(msg + ": " + e);
-                        goToError(msg,e);
+                        XdaqExecutiveResource qrSupervParentExec =
+                            ((XdaqApplicationResource)supervResource).getXdaqExecutiveResourceParent();
+                        logger.info(msgPrefix + "got supervisor executive " + qrSupervParentExec.getApplicationClassName());
+                        supervExecURI = qrSupervParentExec.getURI();
+                        QualifiedResource qrExec = m_gemQG.seekQualifiedResourceOfURI(supervExecURI);
+                        XdaqExecutive     ex     = (XdaqExecutive) qrExec;
+                        logger.info(msgPrefix + "killing supervisor executive with URI " + supervExecURI.toString()
+                                    + ", executive initialized: " + ex.isInitialized());
+                        try {
+                            logger.info(msgPrefix + "killing supervisor executive " + ex.getName());
+                            // ex.destroy();
+                            ex.killMe();
+                        } catch (Exception e) {
+                            String msg = "Exception when destroying supervisor executive named:" + ex.getName()
+                                + " with URI " + ex.getURI().toString();
+                            logger.error(msgPrefix + msg, e);
+                            goToError(msg, e);
+                            throw (UserActionException) e;
+                        }
+                    } catch (Exception e) {
+                        String msg = "Exception when gettting supervisor executive";
+                        logger.error(msgPrefix + msg, e);
+                        goToError(msg, e);
                         throw (UserActionException) e;
                     }
                 }
-                logger.info(msgPrefix + "destroyXDAQ: done killing supervisor executives");
+                logger.info(msgPrefix + "done killing supervisor executives");
             } else {
-                logger.warn(msgPrefix + "destroyXDAQ: unable to find GEMSupervisor executives");
+                logger.warn(msgPrefix + "unable to find GEMSupervisor executives");
             }
         } else {
-            logger.warn(msgPrefix + "destroyXDAQ: unable to find GEMSupervisor container");
+            logger.warn(msgPrefix + "unable to find GEMSupervisor container");
         }
-
+        */
+        
 	// find all XDAQ executives and kill them
 	if (m_gemQG != null) {
-            // if (!m_gemQG.isEmpty()) {
             List<QualifiedResource> qrList = m_gemQG.seekQualifiedResourcesOfType(new XdaqExecutive());
-            logger.info(msgPrefix + "destroyXDAQ: killing all other executives("
-                        + qrList.size() + ") in the QualifiedGroup");
+            logger.info(msgPrefix + "killing all other executives(" + qrList.size() + ") in the QualifiedGroup");
             for (QualifiedResource qr : qrList) {
-                logger.info(msgPrefix + "destroyXDAQ: killing executive " + qr.getName());
+                logger.info(msgPrefix + "killing executive " + qr.getName());
                 XdaqExecutive exec = (XdaqExecutive)qr;
-                logger.info(msgPrefix + "destroyXDAQ: supervisor URI:" + supervExecURI.toString()
+                // logger.info(msgPrefix + "supervisor URI:" + supervExecURI.toString()
+                logger.info(msgPrefix
                             + ", executive URI" + exec.getURI().toString()
                             + ", executive initialized: " + exec.isInitialized());
-                if (!exec.getURI().equals(supervExecURI))
-                    try {
-                        logger.info(msgPrefix + "destroyXDAQ: killing executive " + exec.getName());
-                        // exec.destroy();
-                        exec.killMe();
-                    } catch ( Exception e) {
-                        String msg = "[GEM "+m_FMname+"] destroyXDAQ: Exception when destroying executive named:" + exec.getName()
-                            + " with URI " + exec.getURI().toString();
-                        logger.error(msg + ": " + e);
-                        goToError(msg,e);
-                        throw (UserActionException) e;
-                    }
+                // if (!exec.getURI().equals(supervExecURI)) {
+                try {
+                    logger.info(msgPrefix + "killing executive " + exec.getName());
+                    exec.destroy();
+                    // exec.killMe();
+                } catch ( Exception e) {
+                    String msg = "Exception when destroying executive named:" + exec.getName() + " with URI " + exec.getURI().toString();
+                    logger.error(msgPrefix + msg, e);
+                    goToError(msg,e);
+                    throw (UserActionException) e;
+                }
+                // }
             }
 
-            // List listExecutive = m_gemQG.seekQualifiedResourcesOfType(new XdaqExecutive());
-            // Iterator it = listExecutive.iterator();
-            // while (it.hasNext()) {
-            //     XdaqExecutive ex = (XdaqExecutive) it.next();
-            //     if (!ex.getURI().equals(supervExecURI)) {
-            //         ex.destroy();
-            //     }
-            // }
-            logger.info(msgPrefix + "destroyXDAQ: done killing executives");
-            // } else {
-            //     logger.warn(msgPrefix + "destroyXDAQ: unable to find executives in the QualifiedGroup");
-            // }
+            logger.info(msgPrefix + "done killing executives");
         } else {
-            logger.warn(msgPrefix + "destroyXDAQ: unable to find the QualifiedGroup");
+            logger.warn(msgPrefix + "unable to find the QualifiedGroup");
         }
 
 	// reset the qualified group so that the next time an init is sent all resources will be initialized again
-	//QualifiedGroup qg = getQualifiedGroup();
-        logger.info(msgPrefix + "destroyXDAQ: resetting the QualifiedGroup");
+	// QualifiedGroup qg = getQualifiedGroup();
+        logger.info(msgPrefix + "resetting the QualifiedGroup");
 	if (m_gemQG != null) {
             m_gemQG.reset();
         }
 
-        logger.info(msgPrefix + "destroyXDAQ: done!");
+        logger.info(msgPrefix + "done!");
     }
 
 

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMFunctionManager.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMFunctionManager.java
@@ -203,7 +203,6 @@ public class GEMFunctionManager extends UserFunctionManager {
 
         // make the parameters available
         addParameters();
-
     }
 
     /*
@@ -218,9 +217,11 @@ public class GEMFunctionManager extends UserFunctionManager {
         // This method is called by the framework when the Function Manager is
         // created.
 
-        String msg = "[GEM FM::" + m_FMname + "] createAction called.";
-        System.out.println(msg);
-        logger.debug(msg);
+        String msgPrefix = "[GEM FM] GEMFunctionManager::createAction(ParameterSet<CommandParameter>): ";
+
+        System.out.println(msgPrefix + "createAction called.");
+        logger.debug(msgPrefix + "createAction called.");
+
         m_gemQG = qualifiedGroup;
         // Retrieve the configuration for this Function Manager from the Group
         FunctionManagerResource fmConf = ((FunctionManagerResource) m_gemQG.getGroup().getThisResource());
@@ -235,6 +236,8 @@ public class GEMFunctionManager extends UserFunctionManager {
         dateFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));;
         m_utcFMtimeofstart = dateFormatter.format(m_FMtimeofstart);
 
+        msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::createAction(ParameterSet<CommandParameter>): ";
+
         // set statelistener URL
         try {
             URL fmURL = new URL(m_FMurl);
@@ -243,7 +246,7 @@ public class GEMFunctionManager extends UserFunctionManager {
             String rcmsStateListenerProtocol = fmURL.getProtocol();
             m_rcmsStateListenerURL = rcmsStateListenerProtocol+"://"+rcmsStateListenerHost+":"+rcmsStateListenerPort+"/rcms";
         } catch (MalformedURLException e) {
-            String errMsg = "[GEM FM::" + m_FMname + "] Error! MalformedURLException in createAction" + e.getMessage();
+            String errMsg = msgPrefix + "Error! MalformedURLException in createAction" + e.getMessage();
             logger.error(errMsg,e);
             sendCMSError(errMsg);
             getParameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
@@ -252,16 +255,16 @@ public class GEMFunctionManager extends UserFunctionManager {
         }
 
         // get log session connector
-        logger.info("[GEM FM::" + m_FMname + "] Get log session connector started");
+        logger.info(msgPrefix + "Get log session connector started");
         logSessionConnector = getLogSessionConnector();
-        logger.info("[GEM FM::" + m_FMname + "] Get log session connector finished");
+        logger.info(msgPrefix + "Get log session connector finished");
 
         // get session ID // NEEDS TO BE REMOVED FOR GLOBAL OPERATIONS
-        logger.info("[GEM FM::" + m_FMname + "] Get session ID started");
+        logger.info(msgPrefix + "Get session ID started");
         getSessionId();
-        logger.info("[GEM FM::" + m_FMname + "] Get session ID finished");
+        logger.info(msgPrefix + "Get session ID finished");
 
-        logger.debug("[GEM FM::" + m_FMname + "] createAction executed.");
+        logger.debug(msgPrefix + "createAction executed.");
     }
 
     /*
@@ -278,8 +281,10 @@ public class GEMFunctionManager extends UserFunctionManager {
         //
         //m_gemQG.destroy();
 
-        System.out.println("[GEM FM::" + m_FMname + "] destroyAction called");
-        logger.debug("[GEM FM::" + m_FMname + "] destroyAction called");
+        String msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::destroyAction(): ";
+
+        System.out.println(msgPrefix + "destroyAction called");
+        logger.debug(msgPrefix + "destroyAction called");
 
         // try to close any open session ID only if we are in local run mode i.e. not CDAQ and not miniDAQ runs and if it's a LV1FM
         // if (RunType.equals("local") && !containerFMChildren.isEmpty()) { closeSessionId(); }
@@ -299,10 +304,10 @@ public class GEMFunctionManager extends UserFunctionManager {
         if (c_tcdsControllers != null){
             if (!c_tcdsControllers.isEmpty()) {
                 try {
-                    logger.info("[GEM FM::" + m_FMname + "] Trying to halt TCDS on destroy.");
+                    logger.info(msgPrefix + "Trying to halt TCDS on destroy.");
                     haltTCDSControllers();
                 } catch (UserActionException e) {
-                    String msg = "[GEM FM::" + m_FMname + "] destroyAction: got an exception while halting TCDS";
+                    String msg = msgPrefix + "destroyAction: got an exception while halting TCDS";
                     logger.error(msg + ": " + e);
                     goToError(msg,e);
                 }
@@ -314,12 +319,12 @@ public class GEMFunctionManager extends UserFunctionManager {
         //     throw e;
         // }
 
-        String msg = "[GEM FM::" + m_FMname + "] destroyAction: destroying the Qualified Group";
+        String msg = msgPrefix + "destroyAction: destroying the Qualified Group";
         logger.info(msg);
         this.getQualifiedGroup().destroy();
 
-        System.out.println("[GEM FM::" + m_FMname + "] destroyAction executed");
-        logger.debug("[GEM FM::" + m_FMname + "] destroyAction executed");
+        System.out.println(msgPrefix + "destroyAction executed");
+        logger.debug(msgPrefix + "destroyAction executed");
     }
 
     /**
@@ -335,7 +340,7 @@ public class GEMFunctionManager extends UserFunctionManager {
         throws StateMachineDefinitionException,
                rcms.fm.fw.EventHandlerException
     {
-        String msgPrefix = "[GEM FM:: " + m_FMname + " GEMFunctionManager::init(): ";
+        String msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::init(): ";
 
         // Set first of all the State Machine Definition
         logger.info(msgPrefix + "Setting the state machine definition");
@@ -360,7 +365,7 @@ public class GEMFunctionManager extends UserFunctionManager {
     @SuppressWarnings("unchecked") // SHOULD REALLY MAKE SURE THAT THIS IS NECESSARY AND NOT JUST DUE TO BAD JAVA
         protected void getSessionId()
     {
-        String msgPrefix = "[GEM FM:: " + m_FMname + " GEMFunctionManager::getSessionId(): ";
+        String msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::getSessionId(): ";
 
         String user        = getQualifiedGroup().getGroup().getDirectory().getUser();
         String description = getQualifiedGroup().getGroup().getDirectory().getFullPath();
@@ -390,22 +395,24 @@ public class GEMFunctionManager extends UserFunctionManager {
     // close session Id. This routine is called always when functionmanager gets destroyed.
     protected void closeSessionId()
     {
+        String msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::closeSessionId(): ";
+
         if (logSessionConnector != null) {
             int sessionId = 0;
             try {
                 sessionId = ((IntegerT)getParameterSet().get(GEMParameters.SID).getValue()).getInteger();
             } catch (Exception e) {
-                logger.warn("[GEM FM::" + m_FMname + "] Could not get sessionId for closing session.\n"
+                logger.warn(msgPrefix + "Could not get sessionId for closing session.\n"
                             + "Not closing session.\n"
                             + "(This is OK if no sessionId was requested from within GEM land, i.e. global runs)."
                             + "Exception: ", e);
             }
             try {
-                logger.debug("[GEM FM::" + m_FMname + "] Trying to close log sessionId = " + sessionId );
+                logger.debug(msgPrefix + "Trying to close log sessionId = " + sessionId );
                 logSessionConnector.closeSession(sessionId);
-                logger.debug("[GEM FM::" + m_FMname + "] ... closed log sessionId = " + sessionId );
+                logger.debug(msgPrefix + "... closed log sessionId = " + sessionId );
             } catch (LogSessionException e1) {
-                logger.warn("[GEM FM::" + m_FMname + "] Could not close sessionId, but sessionId was requested and used.\n"
+                logger.warn(msgPrefix + "Could not close sessionId, but sessionId was requested and used.\n"
                             + "This is OK only for global runs.\n"
                             + "Exception: ", e1);
             }
@@ -417,30 +424,36 @@ public class GEMFunctionManager extends UserFunctionManager {
     public boolean isDegraded()
     {
         // FM may check whether it is currently degraded if such functionality exists
+        String msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::isDegraded(): ";
         return degraded;
     }
 
     public boolean hasSoftError()
     {
         // FM may check whether the system has a soft error if such functionality exists
+        String msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::hasSoftError(): ";
         return softErrorDetected;
     }
 
     // only needed if FM cannot check for degradation
     public void setDegraded(boolean degraded)
     {
+        String msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::setDegraded(boolean): ";
         this.degraded = degraded;
     }
 
     // only needed if FM cannot check for softError
     public void setSoftErrorDetected(boolean softErrorDetected)
     {
+        String msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::setSoftErrorDetected(boolean): ";
         this.softErrorDetected = softErrorDetected;
     }
 
     @SuppressWarnings("unchecked")
         protected void sendCMSError(String errMessage)
     {
+        String msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::sendCMSError(String): ";
+
         // create a new error notification msg
         CMSError error = getErrorFactory().getCMSError();
         error.setDateTime(new Date().toString());
@@ -453,7 +466,7 @@ public class GEMFunctionManager extends UserFunctionManager {
         try {
             getParentErrorNotifier().sendError(error);
         } catch (Exception e) {
-            logger.warn("[GEM FM::" + m_FMname + "] " + getClass().toString() + ": Failed to send error message " + errMessage);
+            logger.warn(msgPrefix + "" + getClass().toString() + ": Failed to send error message " + errMessage);
         }
     }
 
@@ -462,6 +475,8 @@ public class GEMFunctionManager extends UserFunctionManager {
      * set the current Action
      */
     public void setAction(String action) {
+
+        String msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::setAction(String): ";
 
         getParameterSet().put(new FunctionManagerParameter<StringT>
                               ("ACTION_MSG",new StringT(action)));
@@ -473,6 +488,7 @@ public class GEMFunctionManager extends UserFunctionManager {
      */
     public void goToError(String errMessage, Exception e)
     {
+        String msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::goToError(String, Exception): ";
         errMessage += " Message from the caught exception is: "+e.getMessage();
         goToError(errMessage);
     }
@@ -482,7 +498,9 @@ public class GEMFunctionManager extends UserFunctionManager {
      */
     public void goToError(String errMessage)
     {
-        logger.error("[GEM FM::" + m_FMname + "] " + errMessage);
+        String msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::goToError(String): ";
+
+        logger.error(msgPrefix + "" + errMessage);
         sendCMSError(errMessage);
         getParameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
         getParameterSet().put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(errMessage)));
@@ -499,6 +517,8 @@ public class GEMFunctionManager extends UserFunctionManager {
     public void getTCDSTaskSequence(Input input)
         throws UserActionException
     {
+        String msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::getTCDSTaskSequence(Input): ";
+
         TaskSequence tcdsSequence = null;
         // Input is INITIALIZE/HALT
         // LPM then iCI, then PI
@@ -524,6 +544,7 @@ public class GEMFunctionManager extends UserFunctionManager {
     public void getTCDSCommandParameters(Input input)
         throws UserActionException
     {
+        String msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::getTCDSCommandParameters(Input): ";
         Map<String, ParameterSet<CommandParameter> > tcdsParameters = null;
         // Input is INITIALIZE
         // Input is HALT
@@ -543,23 +564,25 @@ public class GEMFunctionManager extends UserFunctionManager {
     public void haltTCDSControllers()
         throws UserActionException
     {
+        String msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::haltTCDSControllers(): ";
+
         // ParameterSet<CommandParameter> pSet = new ParameterSet<CommandParameter>();
         // int sessionId = ((IntegerT)getParameterSet().get(GEMParameters.SID).getValue()).getInteger();
         // pSet.put(new FunctionManagerParameter<IntegerT>("SID", new IntegerT(sessionId)));
 
         try {
             if (!c_lpmControllers.isEmpty()) {
-                logger.info("[GEM FM::" + m_FMname + "]  Sending halt to LPM ");
+                logger.info(msgPrefix + " Sending halt to LPM ");
                 c_lpmControllers.execute(GEMInputs.HALT);
                 // if LPM is not a service app, need to provide rcmsURL
                 //lpmApp.execute(GEMInputs.HALT,"test",m_rcmsStateListenerURL);
             }
             if (!c_iciControllers.isEmpty()) {
-                logger.info("[GEM FM::" + m_FMname + "]  Sending halt to iCI ");
+                logger.info(msgPrefix + " Sending halt to iCI ");
                 c_iciControllers.execute(GEMInputs.HALT);
             }
             if (!c_piControllers.isEmpty()) {
-                logger.info("[GEM FM::" + m_FMname + "]  Sending halt to PI ");
+                logger.info(msgPrefix + " Sending halt to PI ");
                 c_piControllers.execute(GEMInputs.HALT);
             }
         } catch (QualifiedResourceContainerException e) {
@@ -579,6 +602,8 @@ public class GEMFunctionManager extends UserFunctionManager {
     public void configureTCDSControllers()
         throws UserActionException
     {
+        String msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::configureTCDSControllers(): ";
+
         try {
             TaskSequence configureTaskSeq = new TaskSequence(GEMStates.CONFIGURING,GEMInputs.SETCONFIGURE);
 
@@ -587,7 +612,7 @@ public class GEMFunctionManager extends UserFunctionManager {
             Input configureInputPI  = new Input(GEMInputs.CONFIGURE.toString());
             SimpleTask lpmConfigureTask,piConfigureTask,iciConfigureTask;
             if (!c_lpmControllers.isEmpty()) {
-                logger.info("[GEM FM::" + m_FMname + "]  Sending configure to LPM ");
+                logger.info(msgPrefix + " Sending configure to LPM ");
                 // add LPM configuration string to CommandParameter
                 ParameterSet<CommandParameter> pSet = new ParameterSet<CommandParameter>();
                 pSet.put(new CommandParameter<StringT>("hardwareConfigurationString", new StringT("")));
@@ -605,7 +630,7 @@ public class GEMFunctionManager extends UserFunctionManager {
             }
 
             if (!c_piControllers.isEmpty()) {
-                logger.info("[GEM FM::" + m_FMname + "]  Sending configure to PI ");
+                logger.info(msgPrefix + " Sending configure to PI ");
                 // add PI configuration string to CommandParameter
                 ParameterSet<CommandParameter> pSet = new ParameterSet<CommandParameter>();
                 pSet.put(new CommandParameter<StringT>("hardwareConfigurationString", new StringT("")));
@@ -623,7 +648,7 @@ public class GEMFunctionManager extends UserFunctionManager {
             }
 
             if (!c_iciControllers.isEmpty()) {
-                logger.info("[GEM FM::" + m_FMname + "]  Sending configure to iCI ");
+                logger.info(msgPrefix + " Sending configure to iCI ");
                 // add ICI configuration string to CommandParameter
                 ParameterSet<CommandParameter> pSet = new ParameterSet<CommandParameter>();
                 pSet.put(new CommandParameter<StringT>("hardwareConfigurationString", new StringT("")));
@@ -662,19 +687,21 @@ public class GEMFunctionManager extends UserFunctionManager {
     public void enableTCDSControllers()
         throws UserActionException
     {
+        String msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::enableTCDSControllers(): ";
+
         try {
             if (!c_lpmControllers.isEmpty()) {
-                logger.info("[GEM FM::" + m_FMname + "]  Sending enable to LPM ");
+                logger.info(msgPrefix + " Sending enable to LPM ");
                 c_lpmControllers.execute(GEMInputs.ENABLE);
                 // if LPM is not a service app, need to provide rcmsURL
                 //lpmApp.execute(GEMInputs.ENABLE,"test",m_rcmsStateListenerURL);
             }
             if (!c_piControllers.isEmpty()) {
-                logger.info("[GEM FM::" + m_FMname + "]  Sending enable to PI ");
+                logger.info(msgPrefix + " Sending enable to PI ");
                 c_piControllers.execute(GEMInputs.ENABLE);
             }
             if (!c_iciControllers.isEmpty()) {
-                logger.info("[GEM FM::" + m_FMname + "]  Sending enable to iCI ");
+                logger.info(msgPrefix + " Sending enable to iCI ");
                 c_iciControllers.execute(GEMInputs.ENABLE);
             }
         } catch (QualifiedResourceContainerException e) {
@@ -694,19 +721,21 @@ public class GEMFunctionManager extends UserFunctionManager {
     public void stopTCDSControllers()
         throws UserActionException
     {
+        String msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::stopTCDSControllers(): ";
+
         try {
             if (!c_lpmControllers.isEmpty()) {
-                logger.info("[GEM FM::" + m_FMname + "]  Sending stop to LPM ");
+                logger.info(msgPrefix + " Sending stop to LPM ");
                 c_lpmControllers.execute(GEMInputs.STOP);
                 // if LPM is not a service app, need to provide rcmsURL
                 //lpmApp.execute(GEMInputs.STOP,"test",m_rcmsStateListenerURL);
             }
             if (!c_iciControllers.isEmpty()) {
-                logger.info("[GEM FM::" + m_FMname + "]  Sending stop to iCI ");
+                logger.info(msgPrefix + " Sending stop to iCI ");
                 c_iciControllers.execute(GEMInputs.STOP);
             }
             if (!c_piControllers.isEmpty()) {
-                logger.info("[GEM FM::" + m_FMname + "]  Sending stop to PI ");
+                logger.info(msgPrefix + " Sending stop to PI ");
                 c_piControllers.execute(GEMInputs.STOP);
             }
         } catch (QualifiedResourceContainerException e) {
@@ -726,19 +755,21 @@ public class GEMFunctionManager extends UserFunctionManager {
     public void pauseTCDSControllers()
         throws UserActionException
     {
+        String msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::pauseTCDSControllers(): ";
+
         try {
             if (!c_lpmControllers.isEmpty()) {
-                logger.info("[GEM FM::" + m_FMname + "]  Sending pause to LPM ");
+                logger.info(msgPrefix + " Sending pause to LPM ");
                 c_lpmControllers.execute(GEMInputs.PAUSE);
                 // if LPM is not a service app, need to provide rcmsURL
                 //lpmApp.execute(GEMInputs.PAUSE,"test",m_rcmsStateListenerURL);
             }
             if (!c_iciControllers.isEmpty()) {
-                logger.info("[GEM FM::" + m_FMname + "]  Sending pause to iCI ");
+                logger.info(msgPrefix + " Sending pause to iCI ");
                 c_iciControllers.execute(GEMInputs.PAUSE);
             }
             if (!c_piControllers.isEmpty()) {
-                logger.info("[GEM FM::" + m_FMname + "]  Sending pause to PI ");
+                logger.info(msgPrefix + " Sending pause to PI ");
                 c_piControllers.execute(GEMInputs.PAUSE);
             }
         } catch (QualifiedResourceContainerException e) {
@@ -758,33 +789,35 @@ public class GEMFunctionManager extends UserFunctionManager {
     protected void destroyXDAQ()
         throws UserActionException
     {
-        logger.info("[GEM FM::" + m_FMname + "] destroyXDAQ called");
-	QualifiedGroup qg = getQualifiedGroup();
+        String msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::destroyXDAQ(): ";
+
+        logger.info(msgPrefix + "destroyXDAQ called");
+	// QualifiedGroup qg = getQualifiedGroup();
 
 	// see if there is an exec with a supervisor and kill it first
 	URI supervExecURI = null;
 	if (c_gemSupervisors != null) {
             if (!c_gemSupervisors.isEmpty()) {
-                logger.info("[GEM FM::" + m_FMname + "] destroyXDAQ: killing GEMSupervisor executives ("
+                logger.info(msgPrefix + "destroyXDAQ: killing GEMSupervisor executives ("
                             + c_gemSupervisors.getApplications().size() + ")");
                 for (QualifiedResource qr : c_gemSupervisors.getApplications()) {
                     // Resource supervResource = c_gemSupervisors.getApplications().get(0).getResource();
-                    logger.info("[GEM FM::" + m_FMname + "] destroyXDAQ: killing executive for supervisor process "
+                    logger.info(msgPrefix + "destroyXDAQ: killing executive for supervisor process "
                                 + qr.getName());
                     Resource supervResource = qr.getResource();
-                    logger.info("[GEM FM::" + m_FMname + "] destroyXDAQ: got supervisor resource " + qr.getName());
+                    logger.info(msgPrefix + "destroyXDAQ: got supervisor resource " + qr.getName());
                     XdaqExecutiveResource qrSupervParentExec =
                         ((XdaqApplicationResource)supervResource).getXdaqExecutiveResourceParent();
-                    logger.info("[GEM FM::" + m_FMname + "] destroyXDAQ: got supervisor executive "
+                    logger.info(msgPrefix + "destroyXDAQ: got supervisor executive "
                                 + qrSupervParentExec.getApplicationClassName());
                     supervExecURI = qrSupervParentExec.getURI();
                     QualifiedResource qrExec = m_gemQG.seekQualifiedResourceOfURI(supervExecURI);
                     XdaqExecutive     ex     = (XdaqExecutive) qrExec;
-                    logger.info("[GEM FM::" + m_FMname + "] destroyXDAQ: killing supervisor executive with URI "
+                    logger.info(msgPrefix + "destroyXDAQ: killing supervisor executive with URI "
                                 + supervExecURI.toString()
                                 + ", executive initialized: " + ex.isInitialized());
                     try {
-                        logger.info("[GEM FM::" + m_FMname + "] destroyXDAQ: killing supervisor executive " + ex.getName());
+                        logger.info(msgPrefix + "destroyXDAQ: killing supervisor executive " + ex.getName());
                         // ex.destroy();
                         ex.killMe();
                     } catch ( Exception e) {
@@ -796,29 +829,29 @@ public class GEMFunctionManager extends UserFunctionManager {
                         throw (UserActionException) e;
                     }
                 }
-                logger.info("[GEM FM::" + m_FMname + "] destroyXDAQ: done killing supervisor executives");
+                logger.info(msgPrefix + "destroyXDAQ: done killing supervisor executives");
             } else {
-                logger.warn("[GEM FM::" + m_FMname + "] destroyXDAQ: unable to find GEMSupervisor executives");
+                logger.warn(msgPrefix + "destroyXDAQ: unable to find GEMSupervisor executives");
             }
         } else {
-            logger.warn("[GEM FM::" + m_FMname + "] destroyXDAQ: unable to find GEMSupervisor container");
+            logger.warn(msgPrefix + "destroyXDAQ: unable to find GEMSupervisor container");
         }
 
 	// find all XDAQ executives and kill them
 	if (m_gemQG != null) {
             // if (!m_gemQG.isEmpty()) {
-            List<QualifiedResource> qrList = qg.seekQualifiedResourcesOfType(new XdaqExecutive());
-            logger.info("[GEM FM::" + m_FMname + "] destroyXDAQ: killing all other executives("
+            List<QualifiedResource> qrList = m_gemQG.seekQualifiedResourcesOfType(new XdaqExecutive());
+            logger.info(msgPrefix + "destroyXDAQ: killing all other executives("
                         + qrList.size() + ") in the QualifiedGroup");
             for (QualifiedResource qr : qrList) {
-                logger.info("[GEM FM::" + m_FMname + "] destroyXDAQ: killing executive " + qr.getName());
+                logger.info(msgPrefix + "destroyXDAQ: killing executive " + qr.getName());
                 XdaqExecutive exec = (XdaqExecutive)qr;
-                logger.info("[GEM FM::" + m_FMname + "] destroyXDAQ: supervisor URI:" + supervExecURI.toString()
+                logger.info(msgPrefix + "destroyXDAQ: supervisor URI:" + supervExecURI.toString()
                             + ", executive URI" + exec.getURI().toString()
                             + ", executive initialized: " + exec.isInitialized());
                 if (!exec.getURI().equals(supervExecURI))
                     try {
-                        logger.info("[GEM FM::" + m_FMname + "] destroyXDAQ: killing executive " + exec.getName());
+                        logger.info(msgPrefix + "destroyXDAQ: killing executive " + exec.getName());
                         // exec.destroy();
                         exec.killMe();
                     } catch ( Exception e) {
@@ -838,26 +871,30 @@ public class GEMFunctionManager extends UserFunctionManager {
             //         ex.destroy();
             //     }
             // }
-            logger.info("[GEM FM::" + m_FMname + "] destroyXDAQ: done killing executives");
+            logger.info(msgPrefix + "destroyXDAQ: done killing executives");
             // } else {
-            //     logger.warn("[GEM FM::" + m_FMname + "] destroyXDAQ: unable to find executives in the QualifiedGroup");
+            //     logger.warn(msgPrefix + "destroyXDAQ: unable to find executives in the QualifiedGroup");
             // }
         } else {
-            logger.warn("[GEM FM::" + m_FMname + "] destroyXDAQ: unable to find the QualifiedGroup");
+            logger.warn(msgPrefix + "destroyXDAQ: unable to find the QualifiedGroup");
         }
 
 	// reset the qualified group so that the next time an init is sent all resources will be initialized again
 	//QualifiedGroup qg = getQualifiedGroup();
-        logger.info("[GEM FM::" + m_FMname + "] destroyXDAQ: resetting the QualifiedGroup");
-	if (qg != null) { qg.reset(); }
+        logger.info(msgPrefix + "destroyXDAQ: resetting the QualifiedGroup");
+	if (m_gemQG != null) {
+            m_gemQG.reset();
+        }
 
-        logger.info("[GEM FM::" + m_FMname + "] destroyXDAQ: done!");
+        logger.info(msgPrefix + "destroyXDAQ: done!");
     }
 
 
     private void submitTaskList(TaskSequence taskList)
         throws UserActionException
     {
+        String msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::submitTaskList(TaskSequence): ";
+
         // Make sure that task list belongs to active state we are in
         if (!taskList.getState().equals(this.getState())) {
             String msg = "taskList does not belong to this state \n "
@@ -868,9 +905,9 @@ public class GEMFunctionManager extends UserFunctionManager {
         }
 
         try {
-            logger.info("[GEM FM::" + m_FMname + "]  before taskList.completion(): " + taskList.completion());
+            logger.info(msgPrefix + " before taskList.completion(): " + taskList.completion());
             taskList.startExecution();
-            logger.info("[GEM FM::" + m_FMname + "]  after taskList.completion(): " + taskList.completion());
+            logger.info(msgPrefix + " after taskList.completion(): " + taskList.completion());
         } catch (EventHandlerException e) {
             String msg = e.getMessage();
             this.getParameterSet().get(GEMParameters.ERROR_MSG)
@@ -883,10 +920,10 @@ public class GEMFunctionManager extends UserFunctionManager {
 
         while ( activeTask == null || activeTask.isCompleted()) {
             if (activeTask != null)
-                logger.info("[GEM FM::" + m_FMname + "]  activeTask: " + activeTask + " completed.");
+                logger.info(msgPrefix + " activeTask: " + activeTask + " completed.");
 
             if (taskList.isEmpty()) {
-                logger.warn("[GEM FM::" + m_FMname + "]  taskList is empty, tasks may have completed");
+                logger.warn(msgPrefix + " taskList is empty, tasks may have completed");
                 this.getParameterSet().get(GEMParameters.ACTION_MSG)
                     .setValue(new StringT("Tasks completed."));
                 this.fireEvent(taskList.getCompletionEvent());
@@ -895,7 +932,7 @@ public class GEMFunctionManager extends UserFunctionManager {
                 break;
             } else {
                 activeTask = (Task)taskList.removeFirst();
-                logger.info("[GEM FM::" + m_FMname + "]  Start new task: " + activeTask.getDescription());
+                logger.info(msgPrefix + " Start new task: " + activeTask.getDescription());
                 this.getParameterSet().get(GEMParameters.ACTION_MSG)
                     .setValue( new StringT("Executing: " + activeTask.getDescription()));
                 try {
@@ -915,7 +952,9 @@ public class GEMFunctionManager extends UserFunctionManager {
      *
      * @see rcms.statemachine.user.IUserStateMachine#getUpdatedState()
      */
-    public State getUpdatedState() {
+    public State getUpdatedState()
+    {
+        String msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::getUpdatedState(): ";
 
         // This method is called by the framework when a Function Manager is
         // created (after createAction).
@@ -945,22 +984,27 @@ public class GEMFunctionManager extends UserFunctionManager {
      * Example of calculation of State derived from the State of the controlled
      * resources.
      */
-    public void defineConditionState() {
+    public void defineConditionState()
+    {
+        String msgPrefix = "[GEM FM::" + m_FMname + "] GEMFunctionManager::defineConditionState(): ";
 
         // The getAll methods must be called only when the m_gemQG is
         // initialized.
-        logger.debug("[GEM FM::" + m_FMname + "] defineConditionState");
+        logger.debug(msgPrefix + "defineConditionState");
 
         // Conditions for State OFF
         StateVector initialConds = new StateVector();
         initialConds.registerConditionState(c_tcdsControllers, GEMStates.HALTED);
+        initialConds.registerConditionState(c_uFEDKIT,         GEMStates.HALTED);
         initialConds.registerConditionState(c_gemSupervisors,  GEMStates.INITIAL);
         initialConds.registerConditionState(c_FMs,             GEMStates.INITIAL);
+        initialConds.registerConditionState(c_uFEDKIT,         GEMStates.HALTED);
         initialConds.setResultState(GEMStates.INITIAL);
 
         // Conditions for State HALTED
         StateVector haltedConds = new StateVector();
         haltedConds.registerConditionState(c_tcdsControllers, GEMStates.HALTED);
+        haltedConds.registerConditionState(c_uFEDKIT,         GEMStates.HALTED);
         haltedConds.registerConditionState(c_gemSupervisors,  GEMStates.HALTED);
         haltedConds.registerConditionState(c_FMs,             GEMStates.HALTED);
         haltedConds.setResultState(GEMStates.HALTED);
@@ -968,13 +1012,47 @@ public class GEMFunctionManager extends UserFunctionManager {
         // Conditions for State CONFIGURED
         StateVector configuredConds = new StateVector();
         configuredConds.registerConditionState(c_tcdsControllers, GEMStates.CONFIGURED);
+        configuredConds.registerConditionState(c_uFEDKIT,         GEMStates.CONFIGURED);
         configuredConds.registerConditionState(c_gemSupervisors,  GEMStates.CONFIGURED);
         configuredConds.registerConditionState(c_FMs,             GEMStates.CONFIGURED);
         configuredConds.setResultState(GEMStates.CONFIGURED);
 
+        // // Conditions for State RUNNING/ENABLED
+        // StateVector runningConds = new StateVector();
+        // runningConds.registerConditionState(c_tcdsControllers, GEMStates.RUNNING);
+        // runningConds.registerConditionState(c_uFEDKIT,         GEMStates.RUNNING);
+        // runningConds.registerConditionState(c_gemSupervisors,  GEMStates.RUNNING);
+        // runningConds.registerConditionState(c_FMs,             GEMStates.RUNNING);
+        // runningConds.setResultState(GEMStates.RUNNING);
+
+        // // Conditions for State RUNNINGDEGRADED
+        // StateVector runningdegradedConds = new StateVector();
+        // runningdegradedConds.registerConditionState(c_tcdsControllers, GEMStates.RUNNINGDEGRADED);
+        // runningdegradedConds.registerConditionState(c_uFEDKIT,         GEMStates.RUNNINGDEGRADED);
+        // runningdegradedConds.registerConditionState(c_gemSupervisors,  GEMStates.RUNNINGDEGRADED);
+        // runningdegradedConds.registerConditionState(c_FMs,             GEMStates.RUNNINGDEGRADED);
+        // runningdegradedConds.setResultState(GEMStates.RUNNINGDEGRADED);
+
+        // // Conditions for State RUNNINGSOFTERRORDETECTED
+        // StateVector runningsofterrordetectedConds = new StateVector();
+        // runningsofterrordetectedConds.registerConditionState(c_tcdsControllers, GEMStates.RUNNINGSOFTERRORDETECTED);
+        // runningsofterrordetectedConds.registerConditionState(c_uFEDKIT,         GEMStates.RUNNINGSOFTERRORDETECTED);
+        // runningsofterrordetectedConds.registerConditionState(c_gemSupervisors,  GEMStates.RUNNINGSOFTERRORDETECTED);
+        // runningsofterrordetectedConds.registerConditionState(c_FMs,             GEMStates.RUNNINGSOFTERRORDETECTED);
+        // runningsofterrordetectedConds.setResultState(GEMStates.RUNNINGSOFTERRORDETECTED);
+
+        // // Conditions for State PAUSED
+        // StateVector pausedConds = new StateVector();
+        // pausedConds.registerConditionState(c_tcdsControllers, GEMStates.PAUSED);
+        // pausedConds.registerConditionState(c_uFEDKIT,         GEMStates.PAUSED);
+        // pausedConds.registerConditionState(c_gemSupervisors,  GEMStates.PAUSED);
+        // pausedConds.registerConditionState(c_FMs,             GEMStates.PAUSED);
+        // pausedConds.setResultState(GEMStates.PAUSED);
+
         // Conditions for State ERROR
         StateVector errorConds = new StateVector();
         errorConds.registerConditionState(c_tcdsControllers, GEMStates.ERROR);
+        errorConds.registerConditionState(c_uFEDKIT,         GEMStates.ERROR);
         errorConds.registerConditionState(c_gemSupervisors,  GEMStates.ERROR);
         errorConds.registerConditionState(c_FMs,             GEMStates.ERROR);
         errorConds.setResultState(GEMStates.ERROR);
@@ -986,8 +1064,12 @@ public class GEMFunctionManager extends UserFunctionManager {
         m_svCalc.add(initialConds);
         m_svCalc.add(haltedConds);
         m_svCalc.add(configuredConds);
+        // m_svCalc.add(runningConds);
+        // m_svCalc.add(runningdegradedConds);
+        // m_svCalc.add(runningsofterrordetectedConds);
+        // m_svCalc.add(pausedConds);
         m_svCalc.add(errorConds);
 
-        logger.debug("[GEM FM::" + m_FMname + "] Condition States defined");
+        logger.debug(msgPrefix + "Condition States defined");
     }
 }

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMFunctionManager.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMFunctionManager.java
@@ -840,7 +840,7 @@ public class GEMFunctionManager extends UserFunctionManager {
             logger.warn(msgPrefix + "unable to find GEMSupervisor container");
         }
         */
-        
+
 	// find all XDAQ executives and kill them
 	if (m_gemQG != null) {
             List<QualifiedResource> qrList = m_gemQG.seekQualifiedResourcesOfType(new XdaqExecutive());
@@ -858,7 +858,8 @@ public class GEMFunctionManager extends UserFunctionManager {
                     exec.destroy();
                     // exec.killMe();
                 } catch ( Exception e) {
-                    String msg = "Exception when destroying executive named:" + exec.getName() + " with URI " + exec.getURI().toString();
+                    String msg = "Exception when destroying executive named:" + exec.getName()
+                        + " with URI " + exec.getURI().toString();
                     logger.error(msgPrefix + msg, e);
                     goToError(msg,e);
                     throw (UserActionException) e;

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMStateMachineDefinition.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMStateMachineDefinition.java
@@ -185,18 +185,18 @@ public class GEMStateMachineDefinition extends UserStateMachineDefinition {
 
         // define parameter set
         ParameterSet<CommandParameter> configureParameters = new ParameterSet<CommandParameter>();
-        try {
-            configureParameters.add(configureSID);
-            // configureParameters.add(configureFedEnableMask);
-            configureParameters.add(configureRunNumber);
-            configureParameters.add(configureRunKey);
-            // configureParameters.add(configureLPMHWCfg);
-            // configureParameters.add(configureICIHWCfg);
-            // configureParameters.add(configurePIHWCfg);
-        } catch (ParameterException nothing) {
-            // Throws an exception if a parameter is duplicate
-            throw new StateMachineDefinitionException( "Could not add to configureParameters. Duplicate Parameter?", nothing );
-        }
+        // try {
+        //     // configureParameters.add(configureSID);
+        //     // configureParameters.add(configureFedEnableMask);
+        //     // configureParameters.add(configureRunNumber);
+        //     // configureParameters.add(configureRunKey);
+        //     // configureParameters.add(configureLPMHWCfg);
+        //     // configureParameters.add(configureICIHWCfg);
+        //     // configureParameters.add(configurePIHWCfg);
+        // } catch (ParameterException nothing) {
+        //     // Throws an exception if a parameter is duplicate
+        //     throw new StateMachineDefinitionException( "Could not add to configureParameters. Duplicate Parameter?", nothing );
+        // }
 
         GEMInputs.CONFIGURE.setParameters(configureParameters);
 

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMStateNotificationHandler.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMStateNotificationHandler.java
@@ -60,9 +60,15 @@ public class GEMStateNotificationHandler extends UserEventHandler  {
         StateNotification notification = (StateNotification)notice;
         String            actualState  = m_gemFM.getState().getStateString();
 
+        logger.info(msgPrefix + "current state is: " + actualState
+                    + ", processing state notification: " + notification
+                    + ", taskSequence: " + m_taskSequence
+                    + ", activeTask: " + m_activeTask);
+                    // + ", isCompleted: " + m_activeTask.isCompleted());
+
         if (m_gemFM.getState().equals(GEMStates.ERROR)) {
-            String msg = msgPrefix + "is in error state: " + m_gemFM.getState();
-            logger.warn(msg);
+            String msg = "is in error state: " + m_gemFM.getState();
+            logger.warn(msgPrefix + msg);
             return;
         }
 
@@ -72,8 +78,8 @@ public class GEMStateNotificationHandler extends UserEventHandler  {
         // do a while loop to cover synchronous tasks which finish immediately
         while (m_activeTask == null || m_activeTask.isCompleted()) {
             if (m_activeTask != null) {
-                String msg = msgPrefix + "m_activeTask: " + m_activeTask + " completed.";
-                logger.info(msg);
+                String msg = "m_activeTask: " + m_activeTask + " completed.";
+                logger.info(msgPrefix + msg);
             }
 
             if (m_taskSequence.isEmpty()) {

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMStateNotificationHandler.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMStateNotificationHandler.java
@@ -1,10 +1,15 @@
 package rcms.fm.app.gemfm;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 import rcms.fm.fw.parameter.FunctionManagerParameter;
 import rcms.fm.fw.parameter.type.StringT;
 
 import rcms.fm.fw.user.UserActionException;
 import rcms.fm.fw.user.UserEventHandler;
+
+import rcms.fm.resource.QualifiedResource;
 
 import rcms.stateFormat.StateNotification;
 import rcms.statemachine.definition.State;
@@ -13,7 +18,6 @@ import rcms.util.logger.RCMSLogger;
 
 import rcms.utilities.fm.task.Task;
 import rcms.utilities.fm.task.TaskSequence;
-
 
 /**
  * StateNotificationHandler for GEM
@@ -72,46 +76,162 @@ public class GEMStateNotificationHandler extends UserEventHandler  {
             return;
         }
 
-
-        // logger.info(msgPrefix + "m_taskSequence.size(): " + m_taskSequence.size());
-
-        // do a while loop to cover synchronous tasks which finish immediately
-        while (m_activeTask == null || m_activeTask.isCompleted()) {
-            if (m_activeTask != null) {
-                String msg = "m_activeTask: " + m_activeTask + " completed.";
-                logger.info(msgPrefix + msg);
-            }
-
-            if (m_taskSequence.isEmpty()) {
-                String msg = "TaskSequence is empty, tasks may have completed";
-                logger.warn(msgPrefix + msg);
-                m_gemFM.setAction(msg);
-                try {
-                    completeTransition();
-                } catch (Exception e) {
-                    m_taskSequence = null;
-                    msg = "Exception while completing TaskSequence ["
-                        + m_taskSequence.getDescription() + "]: " + e.getMessage();
+        try {
+            if (notice instanceof TaskSequence) {
+                if (m_activeTask != null) {
+                    String msg = "activeList not null in first invocatiion";
                     logger.error(msgPrefix + msg);
-                    m_gemFM.setAction(msg);
+                    throw new UserActionException(msg);
                 }
-                break;
-            } else {
-                m_activeTask = (Task)m_taskSequence.removeFirst();
-                logger.info(msgPrefix + "Start next task: " + m_activeTask.getDescription());
-                m_gemFM.setAction("Executing: " + m_activeTask.getDescription());
-                try {
-                    m_activeTask.startExecution();
-                    logger.info(msgPrefix + "After TaskSequence::startExecution(): " + m_taskSequence.completion());
-                } catch (Exception e) {
-                    m_taskSequence = null;
-                    String msg = "Exception while moving to the next task: " + e.getMessage();
-                    handleError(msg,msg);
+                if (m_taskSequence != null) {
+                    String msg = "taskSequence not null in first invocation";
+                    logger.error(msgPrefix + msg);
+                    throw new UserActionException(msg);
+                }
+                m_taskSequence = (TaskSequence)notice;
+
+                if (m_taskSequence.isEmpty()) {
+                    String msg = "New task notification received but it is empty";
+                    logger.error(msgPrefix + msg);
+                    throw new UserActionException(msg);
                 }
             }
+
+            if (notice instanceof StateNotification) {
+                // debug
+                StateNotification tmp = (StateNotification)notice;
+                String debugMsg = "StateNotification: ";
+                if (tmp != null)
+                    debugMsg+= tmp.getToState();
+                if (m_taskSequence != null && m_taskSequence.getCompletionEvent() != null)
+                    debugMsg += "\n inputAtCompletion: " + m_taskSequence.getCompletionEvent().toString();
+                logger.debug(msgPrefix + debugMsg);
+
+                // prepare state notification
+                StateNotification sn = (StateNotification)notice;
+                String toState       = sn.getToState();
+                QualifiedResource qr = findQRFromSN(sn);
+
+                if (toState == null ) {
+                    logger.warn(msgPrefix + "Received StateNotification with toState==null.");
+                    return;
+                }
+
+                if (toState.equals(GEMStates.ERROR.toString()) ||
+                    toState.equals(GEMStates.FAILED.toString())) {// ||
+                    // toState.equals(RCMSConstants.LEASE_RENEWAL_FAILED)) {
+                    // fire event to go to error
+                    fail("Received " + toState + " notification from " + qr.getURI() + "\n" +
+                          "Reason given: " + sn.getReason() );
+                    return;
+                }
+                if (m_taskSequence == null) {
+                    String msg = "Received an unexpected StateNotification while taskSequence is null\n"
+                        + printStateChangedNotice(sn);
+                    logger.warn(msgPrefix + msg);
+                    return;
+                }
+
+                // // REQUIRES TCDS REIMPLEMENTATION OF Task.java, WHICH IS AWFUL FORM AND SHOULD JUST BE PUT BACK INTO THE MAINLINE
+                // // if there is an active task, send state notification to it
+                // if( m_activeTask != null ) {
+                //     m_activeTask.processStateNotification(qr, toState);
+                // }
+            }
+
+            // logger.info(msgPrefix + "m_taskSequence.size(): " + m_taskSequence.size());
+            if (m_taskSequence == null) {
+                setTimeoutThread(false);
+                String infomsg = "Received a State Notification while taskSequence is null\n";
+
+                logger.debug(msgPrefix + "FM is in local mode");
+                // m_gemFM.m_gemEventHandler.computeNewState(notification);
+                return;
+            }
+
+            // do a while loop to cover synchronous tasks which finish immediately
+            while (m_activeTask == null || m_activeTask.isCompleted()) {
+                if (m_activeTask != null) {
+                    String msg = "m_activeTask: " + m_activeTask + " completed.";
+                    logger.info(msgPrefix + msg);
+                }
+
+                if (m_taskSequence.isEmpty()) {
+                    String msg = "TaskSequence is empty, tasks may have completed";
+                    logger.warn(msgPrefix + msg);
+                    m_gemFM.setAction(msg);
+                    try {
+                        completeTransition();
+                    } catch (Exception e) {
+                        m_taskSequence = null;
+                        msg = "Exception while completing TaskSequence ["
+                            + m_taskSequence.getDescription() + "]: " + e.getMessage();
+                        logger.error(msgPrefix + msg);
+                        m_gemFM.setAction(msg);
+                    }
+                    break;
+                } else {
+                    m_activeTask = (Task)m_taskSequence.removeFirst();
+                    logger.info(msgPrefix + "Start next task: " + m_activeTask.getDescription());
+                    m_gemFM.setAction("Executing: " + m_activeTask.getDescription());
+                    try {
+                        m_activeTask.startExecution();
+                        logger.info(msgPrefix + "After TaskSequence::startExecution(): " + m_taskSequence.completion());
+                    } catch (Exception e) {
+                        m_taskSequence = null;
+                        String msg = "Exception while moving to the next task: " + e.getMessage();
+                        handleError(msg,msg);
+                    }
+                }
+            }
+        } catch (UserActionException e) {
+            logger.error(msgPrefix + "Caught UserActionException during processing occured.", e);
+            m_gemFM.fireEvent(GEMInputs.SETERROR);
         }
     }
 
+
+    // BEGIN COPIED FROM TCDS CODE, NEEDS TO BE RETHOUGHT
+    private void fail(String msg)
+    {
+        String msgPrefix = "[GEM FM::" + m_gemFM.m_FMname + "] GEMStateNotificationHandler::fail(): ";
+
+        logger.error(msgPrefix + msg);
+
+        ((FunctionManagerParameter<StringT>)m_gemFM.getParameterSet().get(GEMParameters.ERROR_MSG))
+            .setValue( new StringT( escapeErrorMessage(msg) ));
+
+        m_gemFM.fireEvent(GEMInputs.SETERROR);
+    }
+
+
+    private String escapeErrorMessage(String msg)
+    {
+        return msg.replace("<","&lt;").replace(">", "&gt;").replace("\n", "<br/>");
+    }
+
+
+    private QualifiedResource findQRFromSN(StateNotification sn)
+    {
+        try {
+            return m_gemFM.getQualifiedGroup().seekQualifiedResourceOfURI( new URI(sn.getIdentifier()) );
+        } catch (URISyntaxException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+
+    private String printStateChangedNotice(StateNotification notice)
+    {
+        return "StateUpdate " + "\n Destination = " + notice.getDestination()
+            + "\n Identifier  = " + notice.getIdentifier()
+            + "\n fromState   = " + notice.getFromState()
+            + "\n reason      = " + notice.getReason()
+            + "\n toState     = " + notice.getToState();
+    }
+    // END COPIED FROM TCDS CODE
 
     protected void executeTaskSequence(TaskSequence taskSequence)
     // throws UserActionException
@@ -125,9 +245,9 @@ public class GEMStateNotificationHandler extends UserEventHandler  {
 
         // Make sure that task list belongs to active state we are in
         if (!SequenceState.equals(FMState)) {
-            String msg = "taskList does not belong to this state \n "
+            String msg = "taskSequence does not belong to this state \n "
                 + "Function Manager state = " + FMState + "\n"
-                + "taskList is for state = " + SequenceState;
+                + "taskSequence is for state = " + SequenceState;
             logger.error(msg);
             m_taskSequence = null;
             handleError(msg," ");

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMStates.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMStates.java
@@ -30,7 +30,8 @@ public final class GEMStates {
     public static final State RECOVERING = new State("Recovering");
     public static final State RESETTING  = new State("Resetting");
 
-    public static final State ERROR = new State("Error");
+    public static final State ERROR  = new State("Error");
+    public static final State FAILED = new State("Failed");
 
     public static final State PREPARING_TTSTEST_MODE = new State("PreparingTTSTestMode");
     public static final State TTSTEST_MODE           = new State("TTSTestMode");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Provides improved handling of transitions
* Reset of FM properly resets and then initializes GEM resources
* State notification handling does not work as desired, but the templates are all there for reworking

## Description
<!--- Describe your changes in detail -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->

## How Has This Been Tested?
Tested at 904 with the `uFEDKIT_noTCDS` configuration
* Properly steps through the necessary state transitions
* Sending run number to the supervisor is currently not working, but it's working to the fedkit resources, so it may be an issue in the `cmsgemos` XDAQ side, but needs debugging