### PR TITLE
Adding xdaq control

### DIFF
--- a/gemLevelOneFM/duck/gemsupervisor_gem904daq01.xml
+++ b/gemLevelOneFM/duck/gemsupervisor_gem904daq01.xml
@@ -6,34 +6,34 @@
   <xc:Context url="http://gem904daq01:20000">
     <xc:Application class="gem::hw::glib::GLIBManager" id="30" instance="0" network="local">
       <properties xmlns="urn:xdaq-application:gem::hw::glib::GLIBManager"
-		  xsi:type="soapenc:Struct">
-	<AMCSlots       xsi:type="xsd:string">2</AMCSlots> <!-- I AM A TERRIBLE THING-->
-	<ConnectionFile xsi:type="xsd:string">connections.xml</ConnectionFile>
-	<AllGLIBsInfo xsi:type="soapenc:Array"  soapenc:arrayType="xsd:ur-type[12]"> <!-- I AM A TERRIBLE THING-->
-          <GLIBInfo   xsi:type="soapenc:Struct" soapenc:position="1"> <!--  position must be slot-1  -->
-            <crateID  xsi:type="xsd:integer">1</crateID>
-            <slot     xsi:type="xsd:integer">2</slot>
-            <present  xsi:type="xsd:boolean">true</present>
-            <sbitSource    xsi:type="xsd:integer">5</sbitSource>
+        	  xsi:type="soapenc:Struct">
+        <AMCSlots       xsi:type="xsd:string">2</AMCSlots> <!-- I AM A TERRIBLE THING-->
+        <ConnectionFile xsi:type="xsd:string">connections.xml</ConnectionFile>
+        <AllGLIBsInfo   xsi:type="soapenc:Array"  soapenc:arrayType="xsd:ur-type[12]"> <!-- I AM A TERRIBLE THING-->
+          <GLIBInfo     xsi:type="soapenc:Struct" soapenc:position="1"> <!--  position must be slot-1  -->
+            <crateID    xsi:type="xsd:integer">1</crateID>
+            <slot       xsi:type="xsd:integer">2</slot>
+            <present    xsi:type="xsd:boolean">true</present>
+            <sbitSource xsi:type="xsd:integer">5</sbitSource>
           </GLIBInfo>
-	</AllGLIBsInfo>
+        </AllGLIBsInfo>
       </properties>
     </xc:Application>
 
     <xc:Application class="gem::hw::optohybrid::OptoHybridManager" id="50" instance="0" network="local">
       <properties xmlns="urn:xdaq-application:gem::hw::optohybrid::OptoHybridManager"
-		  xsi:type="soapenc:Struct">
-	<ConnectionFile xsi:type="xsd:string">connections.xml</ConnectionFile>
-	<AllOptoHybridsInfo xsi:type="soapenc:Array"  soapenc:arrayType="xsd:ur-type[144]"><!-- MAX_OH_PER_AMC(12) * MAX_AMC_PER_UTCA(12)-->
+        	  xsi:type="soapenc:Struct">
+        <ConnectionFile     xsi:type="xsd:string">connections.xml</ConnectionFile>
+        <AllOptoHybridsInfo xsi:type="soapenc:Array"  soapenc:arrayType="xsd:ur-type[144]"><!-- MAX_OH_PER_AMC(12) * MAX_AMC_PER_UTCA(12)-->
           <OptoHybridInfo   xsi:type="soapenc:Struct" soapenc:position="12"> <!-- position must be (slot-1)*MAX_OH_PER_AMC(12)+link -->
-            <crateID xsi:type="xsd:integer">1</crateID>
-            <slot    xsi:type="xsd:integer">2</slot>
-            <link    xsi:type="xsd:integer">0</link>
-            <present xsi:type="xsd:boolean">true</present>
+            <crateID        xsi:type="xsd:integer">1</crateID>
+            <slot           xsi:type="xsd:integer">2</slot>
+            <link           xsi:type="xsd:integer">0</link>
+            <present        xsi:type="xsd:boolean">true</present>
 
             <triggerSource xsi:type="xsd:integer">0</triggerSource>
 
-            <SBitConfig xsi:type="soapenc:Struct">
+            <SBitConfig   xsi:type="soapenc:Struct">
               <Mode       xsi:type="xsd:unsignedShort">1</Mode>
               <Output0Src xsi:type="xsd:unsignedShort">0</Output0Src>
               <Output1Src xsi:type="xsd:unsignedShort">1</Output1Src>
@@ -58,7 +58,7 @@
             </CommonVFATSettings>
           </OptoHybridInfo>
 
-	</AllOptoHybridsInfo>
+        </AllOptoHybridsInfo>
       </properties>
     </xc:Application>
 
@@ -68,8 +68,8 @@
         <amc13ConfigParams xsi:type="soapenc:Struct">
           <ConnectionFile     xsi:type="xsd:string">connections.xml</ConnectionFile>
 	  <CardName           xsi:type="xsd:string">gem.shelf01.amc13</CardName>
-          <AMCInputEnableList xsi:type="xsd:string">3</AMCInputEnableList>
-          <AMCIgnoreTTSList   xsi:type="xsd:string">0-2,4-15 </AMCIgnoreTTSList>
+          <AMCInputEnableList xsi:type="xsd:string">2</AMCInputEnableList>
+          <AMCIgnoreTTSList   xsi:type="xsd:string">1,3-12</AMCIgnoreTTSList>
 
           <EnableDAQLink       xsi:type="xsd:boolean">true</EnableDAQLink>
           <EnableFakeData      xsi:type="xsd:boolean">false</EnableFakeData>
@@ -114,31 +114,32 @@
       </properties>
     </xc:Application>
 
-    <xc:Application class="gem::hw::amc13::AMC13Readout" id="260" instance="0" network="local">
-      <properties xmlns="urn:xdaq-application:gem::hw::amc13::AMC13Readout"
-		  xsi:type="soapenc:Struct">
-        <ConnectionFile  xsi:type="xsd:string">connections.xml</ConnectionFile>
-        <DeviceName      xsi:type="xsd:string">AMC13</DeviceName>
-        <CardName        xsi:type="xsd:string">gem.shelf01.amc13</CardName>
-        <crateID         xsi:type="xsd:integer">1</crateID>
-        <slot            xsi:type="xsd:integer">13</slot>
-        <ReadoutSettings xsi:type="soapenc:Struct">
-          <runType        xsi:type="xsd:string">ThresholdScan</runType>
-          <fileName       xsi:type="xsd:string">test</fileName>
-          <outputType     xsi:type="xsd:string">BIN</outputType>
-          <outputLocation xsi:type="xsd:string">/tmp/</outputLocation>
-          <setupLocation  xsi:type="xsd:string">CERN904</setupLocation>
-        </ReadoutSettings>
-      </properties>
-    </xc:Application>
+    <!-- <xc:Application class="gem::hw::amc13::AMC13Readout" id="260" instance="0" network="local"> -->
+    <!--   <properties xmlns="urn:xdaq-application:gem::hw::amc13::AMC13Readout" -->
+    <!--     	  xsi:type="soapenc:Struct"> -->
+    <!--     <ConnectionFile  xsi:type="xsd:string">connections.xml</ConnectionFile> -->
+    <!--     <DeviceName      xsi:type="xsd:string">AMC13</DeviceName> -->
+    <!--     <CardName        xsi:type="xsd:string">gem.shelf01.amc13</CardName> -->
+    <!--     <crateID         xsi:type="xsd:integer">1</crateID> -->
+    <!--     <slot            xsi:type="xsd:integer">13</slot> -->
+    <!--     <ReadoutSettings xsi:type="soapenc:Struct"> -->
+    <!--       <runType        xsi:type="xsd:string">ThresholdScan</runType> -->
+    <!--       <fileName       xsi:type="xsd:string">test</fileName> -->
+    <!--       <outputType     xsi:type="xsd:string">BIN</outputType> -->
+    <!--       <outputLocation xsi:type="xsd:string">/tmp/</outputLocation> -->
+    <!--       <setupLocation  xsi:type="xsd:string">CERN904</setupLocation> -->
+    <!--     </ReadoutSettings> -->
+    <!--   </properties> -->
+    <!-- </xc:Application> -->
 
-    <xc:Application class="gem::supervisor::GEMSupervisor" id="254" instance="0" network="local">
+    <xc:Application class="gem::supervisor::GEMSupervisor" id="254" instance="0" network="local" logLevel="INFO">
       <properties xmlns="urn:xdaq-application:GEMSupervisor"
 		  xsi:type="soapenc:Struct">
         <UseLocalDB        xsi:type="xsd:boolean">false</UseLocalDB>
-        <HandleTCDS        xsi:type="xsd:boolean">false</HandleTCDS>
+        <HandleTCDS        xsi:type="xsd:boolean">true</HandleTCDS>
         <UseLocalReadout   xsi:type="xsd:boolean">true</UseLocalReadout>
         <UseFedKitReadout  xsi:type="xsd:boolean">false</UseFedKitReadout>
+        <ReportStateToRCMS xsi:type="xsd:boolean">true</ReportStateToRCMS>
 
         <DatabaseInfo xsi:type="soapenc:Struct">
           <dbName xsi:type="xsd:string">ldqm_test_db</dbName>
@@ -147,13 +148,13 @@
           <dbUser xsi:type="xsd:string">gemdaq</dbUser>
           <dbPass xsi:type="xsd:string">gemdaq</dbPass>
 
-          <setupTag xsi:type="xsd:string">ThresholdScan</setupTag>
+          <setupTag xsi:type="xsd:string">Cosmic</setupTag>
           <runPeriod xsi:type="xsd:string">2017T</runPeriod>
-          <setupLocation xsi:type="xsd:string">CERNP5</setupLocation>
+          <setupLocation xsi:type="xsd:string">CERN904</setupLocation>
         </DatabaseInfo>
 
         <ScanInfo xsi:type="soapenc:Struct">
-          <ScanType   xsi:type="xsd:unsignedInt">3</ScanType>
+          <ScanType   xsi:type="xsd:unsignedInt">1</ScanType>
           <ScanMin    xsi:type="xsd:unsignedInt">0</ScanMin>
           <ScanMax    xsi:type="xsd:unsignedInt">101</ScanMax>
           <StepSize   xsi:type="xsd:unsignedInt">1</StepSize>
@@ -186,17 +187,31 @@
 
   </xc:Context>
 
-  <xc:Context url="http://gem904daq01:10000/rcms">
-    <xc:Application class="RCMSStateListener" id="50" instance="0" network="local" path="/services/replycommandreceiver" />
-    <xc:Module>${XDAQ_ROOT}/lib/libxdaq2rc.so</xc:Module>
-  </xc:Context>
-
   <xc:Context url="http://localhost:12107">
     <xc:Application class="tcds::ici::ICIController" id="303" instance="0" network="local">
+      <properties xmlns="urn:xdaq-application:GEMSupervisor"
+		  xsi:type="soapenc:Struct">
+	<rcmsStateListener xsi:type="soapenc:Struct">
+          <classname xsi:type="xsd:string">RCMSStateListener</classname>
+          <instance  xsi:type="xsd:unsignedInt">0</instance>
+        </rcmsStateListener>
+      </properties>
     </xc:Application>
 
     <xc:Application class="tcds::pi::PIController"   id="503" instance="0" network="local">
+      <properties xmlns="urn:xdaq-application:GEMSupervisor"
+		  xsi:type="soapenc:Struct">
+	<rcmsStateListener xsi:type="soapenc:Struct">
+          <classname xsi:type="xsd:string">RCMSStateListener</classname>
+          <instance  xsi:type="xsd:unsignedInt">0</instance>
+        </rcmsStateListener>
+      </properties>
     </xc:Application>
+  </xc:Context>
+
+  <xc:Context url="http://gem904daq01.cern.ch:10000/rcms">
+    <xc:Application class="RCMSStateListener" id="50" instance="0" network="local" path="/services/replycommandreceiver" />
+    <xc:Module>${XDAQ_ROOT}/lib/libxdaq2rc.so</xc:Module>
   </xc:Context>
 
 </xc:Partition>

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMErrorHandler.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMErrorHandler.java
@@ -3,6 +3,7 @@ package rcms.fm.app.gemfm;
 import rcms.fm.fw.EventHandlerException;
 import rcms.fm.fw.user.UserActionException;
 import rcms.fm.fw.user.UserErrorHandler;
+import rcms.errorFormat.CMS.CMSError;
 import rcms.statemachine.definition.State;
 import rcms.util.logger.RCMSLogger;
 
@@ -34,6 +35,9 @@ public class GEMErrorHandler extends UserErrorHandler {
         // so it is already registered for Error events
         String msgPrefix = "[GEM FM] GEMEventHandler::GEMEventHandler(): ";
 
+	// register for CMSError events
+	subscribeForEvents(CMSError.class);
+
         // error handler
         addAction(State.ANYSTATE, "errorHandler");
 
@@ -56,4 +60,16 @@ public class GEMErrorHandler extends UserErrorHandler {
         System.out.println(msgPrefix + "Got an event: " + obj.getClass() );
         logger.error(msgPrefix + "Got an event: " + obj.getClass() );
     }
+
+    public void setError(CMSError error)
+	throws UserActionException 
+    {
+	try {
+	    m_gemFM.getParentErrorNotifier().sendError(error);
+	} 
+	catch (Exception e) {
+	    throw new UserActionException("Cannot send error", e);
+	}
+    }
+
 }

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
@@ -2332,7 +2332,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 			if (!m_gemFM.c_gemSupervisors.isEmpty()) {
 			    
 			    {
-				String debugMessage = "[GEM " + m_gemFM.FMname + "] GEM supervisor found for checking its state: GEMINI still alive!";
+				String debugMessage = "[GEM " + m_gemFM.m_FMname + "] GEM supervisor found for checking its state: GEMINI still alive!";
 				logger.debug(debugMessage);
 			    }
 
@@ -2353,23 +2353,23 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 				    stateName = pam.getValue("stateName");
 				    
 				    if (status==null || stateName==null) {
-					String errMessage = "[GEM " + m_gemFM.FMname + "] Error! Asking the hcalSupervisor for the PartitionState and stateName to see if it is alive or not resulted in a NULL pointer - this is bad!";
+					String errMessage = "[GEM " + m_gemFM.m_FMname + "] Error! Asking the hcalSupervisor for the PartitionState and stateName to see if it is alive or not resulted in a NULL pointer - this is bad!";
 					m_gemFM.goToError(errMessage);
 				    }
 
-				    logger.debug("[GEM " + m_gemFM.FMname + "] asking for the GEM supervisor PartitionState to see if it is still alive.\n The PartitionState is: " + status);
+				    logger.debug("[GEM " + m_gemFM.m_FMname + "] asking for the GEM supervisor PartitionState to see if it is still alive.\n The PartitionState is: " + status);
 				}
 				catch (XDAQTimeoutException e) {
-				    String errMessage = "[GEM " + m_gemFM.FMname + "] Error! XDAQTimeoutException: GEMSupervisorWatchThread()\nProbably the GEM supervisor application is dead.\nCheck the corresponding jobcontrol status ...\nHere is the exception: " +e;
+				    String errMessage = "[GEM " + m_gemFM.m_FMname + "] Error! XDAQTimeoutException: GEMSupervisorWatchThread()\nProbably the GEM supervisor application is dead.\nCheck the corresponding jobcontrol status ...\nHere is the exception: " +e;
 				    m_gemFM.goToError(errMessage);
 				}
 				catch (XDAQException e) {
-				    String errMessage = "[GEM " + m_gemFM.FMname + "] Error! XDAQException: GEMSupervisorWatchThread()\nProbably the GEM supervisor application is in a bad condition.\nCheck the corresponding jobcontrol status, etc. ...\nHere is the exception: " +e;
+				    String errMessage = "[GEM " + m_gemFM.m_FMname + "] Error! XDAQException: GEMSupervisorWatchThread()\nProbably the GEM supervisor application is in a bad condition.\nCheck the corresponding jobcontrol status, etc. ...\nHere is the exception: " +e;
 				    m_gemFM.goToError(errMessage);
 				}
 
 				if (status.equals("Failed") || status.equals("Faulty") || status.equals("Error") || stateName.equalsIgnoreCase("failed")) {
-				    String errMessage = "[GEM " + m_gemFM.FMname + "] Error! GEMSupervisorWatchThread(): supervisor reports partitionState: " + status + " and stateName: " + stateName +"; ";
+				    String errMessage = "[GEM " + m_gemFM.m_FMname + "] Error! GEMSupervisorWatchThread(): supervisor reports partitionState: " + status + " and stateName: " + stateName +"; ";
 				    String supervisorError = m_gemFM.getSupervisorErrorMessage();
 				    errMessage+=supervisorError;
 				    m_gemFM.goToError(errMessage);
@@ -2377,7 +2377,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 			    }
 			}
 			else {
-			    String errMessage = "[GEM " + m_gemFM.FMname + "] Error! No GEM supervisor found: GEMSupervisorWatchThread()";
+			    String errMessage = "[GEM " + m_gemFM.m_FMname + "] Error! No GEM supervisor found: GEMSupervisorWatchThread()";
 			    m_gemFM.goToError(errMessage);
 			}
 		    }
@@ -2388,10 +2388,10 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 	    }
 
 	    // stop the GEM supervisor watchdog thread
-	    System.out.println("[GEM " + m_gemFM.FMname + "] ... stopping GEM supervisor watchdog thread done.");
-	    logger.debug("[GEM " + m_gemFM.FMname + "] ... stopping GEM supervisor watchdog thread done.");
+	    System.out.println("[GEM " + m_gemFM.m_FMname + "] ... stopping GEM supervisor watchdog thread done.");
+	    logger.debug("[GEM " + m_gemFM.m_FMname + "] ... stopping GEM supervisor watchdog thread done.");
 
-	    GEMSupervisorWatchThreadList.remove(this);
+	    //GEMSupervisorWatchThreadList.remove(this);
 	}
     }
 

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
@@ -2034,10 +2034,13 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                     pam =((XdaqApplication)qr).getXDAQParameter();
                     logger.info(msgPrefix + "initXDAQ: got parameters, selecting:");
 
-                    pam.select(new String[] {"TriggerAdapterName", "PartitionState", "InitializationProgress","ReportStateToRCMS"});
+                    //pam.select(new String[] {"TriggerAdapterName", "PartitionState", "InitializationProgress","ReportStateToRCMS"});
+                    pam.select(new String[] {"HandleTCDS"});
                     logger.info(msgPrefix + "initXDAQ: parameters selected, getting:");
                     pam.get();
-                    logger.info(msgPrefix + "initXDAQ: got selectedparameters!");
+		    boolean DoesSupervisorHandleTCDS =  pam.getValue("HandleTCDS");
+                    logger.info(msgPrefix + "initXDAQ: got selected parameters!");
+		    logger.info(msgPrefix + "HandleTCDS: " + DoesSupervisorHandleTCDS);
 
                     dowehaveanasyncgemSupervisor = pam.getValue("ReportStateToRCMS");
                     msg = msgPrefix + "initXDAQ(): asking for the GEM supervisor "

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
@@ -98,7 +98,6 @@ public class GEMEventHandler extends UserStateNotificationHandler {
      * <code>SID</code>: Session ID for database connections
      */
     public Integer m_SID = 0;
-
     /**
      * <code>RunSequenceName</code>: Run sequence name, for attaining a run sequence number
      */
@@ -151,7 +150,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
         throws rcms.fm.fw.EventHandlerException
     {
         String msgPrefix = "[GEM FM:: " + ((GEMFunctionManager)getUserFunctionManager()).m_FMname
-            + "] GEMEventHandler::GEMEventHandler(): ";
+	+ "] GEMEventHandler::GEMEventHandler(): ";
         // String msgPrefix = "[GEM FM::" + m_gemFM.m_FMname + "] GEMEventHandler::init(): ";
 
         logger.info(msgPrefix + "Starting");
@@ -2303,92 +2302,5 @@ public class GEMEventHandler extends UserStateNotificationHandler {
             }
         }
     }
-
-  // thread which checks the HCAL supervisor state
-  /*protected class HCALSupervisorWatchThread extends Thread {
-
-    public HCALSupervisorWatchThread() {
-      HCALSupervisorWatchThreadList.add(this);
-    }
-
-    public void run() {
-      stopHCALSupervisorWatchThread = false;
-
-      int icount = 0;
-      while ((stopHCALSupervisorWatchThread == false) && (functionManager != null) && (functionManager.isDestroyed() == false)) {
-        icount++;
-        Date now = Calendar.getInstance().getTime();
-
-        // poll HCAL supervisor status in the Configuring/Configured/Running/RunningDegraded states every 5 sec to see if it is still alive  (dangerous because ERROR state is reported wrongly quite frequently)
-        if (icount%5==0) {
-          if ((functionManager.getState().getStateString().equals(HCALStates.CONFIGURING.toString()) ||
-                functionManager.getState().getStateString().equals(HCALStates.CONFIGURED.toString()) ||
-                functionManager.getState().getStateString().equals(HCALStates.RUNNING.toString()) ||
-                functionManager.getState().getStateString().equals(HCALStates.RUNNINGDEGRADED.toString()))) {
-            if (!functionManager.containerhcalSupervisor.isEmpty()) {
-
-              {
-                String debugMessage = "[HCAL " + functionManager.FMname + "] HCAL supervisor found for checking its state i.e. health - good!";
-                logger.debug(debugMessage);
-              }
-
-              XDAQParameter pam = null;
-              String status   = "undefined";
-              String stateName   = "undefined";
-              String progress = "undefined";
-              String taname   = "undefined";
-
-              // ask for the status of the HCAL supervisor
-              for (QualifiedResource qr : functionManager.containerhcalSupervisor.getApplications() ){
-                try {
-                  pam =((XdaqApplication)qr).getXDAQParameter();
-                  pam.select(new String[] {"TriggerAdapterName", "PartitionState", "InitializationProgress", "stateName"});
-                  pam.get();
-
-                  status = pam.getValue("PartitionState");
-                  stateName = pam.getValue("stateName");
-
-                  if (status==null || stateName==null) {
-                    String errMessage = "[HCAL " + functionManager.FMname + "] Error! Asking the hcalSupervisor for the PartitionState and stateName to see if it is alive or not resulted in a NULL pointer - this is bad!";
-                    functionManager.goToError(errMessage);
-                  }
-
-                  logger.debug("[HCAL " + functionManager.FMname + "] asking for the HCAL supervisor PartitionState to see if it is still alive.\n The PartitionState is: " + status);
-                }
-                catch (XDAQTimeoutException e) {
-                  String errMessage = "[HCAL " + functionManager.FMname + "] Error! XDAQTimeoutException: HCALSupervisorWatchThread()\nProbably the HCAL supervisor application is dead.\nCheck the corresponding jobcontrol status ...\nHere is the exception: " +e;
-                  functionManager.goToError(errMessage);
-                }
-                catch (XDAQException e) {
-                  String errMessage = "[HCAL " + functionManager.FMname + "] Error! XDAQException: HCALSupervisorWatchThread()\nProbably the HCAL supervisor application is in a bad condition.\nCheck the corresponding jobcontrol status, etc. ...\nHere is the exception: " +e;
-                  functionManager.goToError(errMessage);
-                }
-
-                if (status.equals("Failed") || status.equals("Faulty") || status.equals("Error") || stateName.equalsIgnoreCase("failed")) {
-                  String errMessage = "[HCAL " + functionManager.FMname + "] Error! HCALSupervisorWatchThread(): supervisor reports partitionState: " + status + " and stateName: " + stateName +"; ";
-                  String supervisorError = ((HCALlevelTwoFunctionManager)functionManager).getSupervisorErrorMessage();
-                  errMessage+=supervisorError;
-                  functionManager.goToError(errMessage);
-                }
-              }
-            }
-            else {
-              String errMessage = "[HCAL " + functionManager.FMname + "] Error! No HCAL supervisor found: HCALSupervisorWatchThread()";
-              functionManager.goToError(errMessage);
-            }
-          }
-        }
-        // delay between polls
-        try { Thread.sleep(1000); }
-        catch (Exception ignored) { return; }
-      }
-
-      // stop the HCAL supervisor watchdog thread
-      System.out.println("[HCAL " + functionManager.FMname + "] ... stopping HCAL supervisor watchdog thread done.");
-      logger.debug("[HCAL " + functionManager.FMname + "] ... stopping HCAL supervisor watchdog thread done.");
-
-      HCALSupervisorWatchThreadList.remove(this);
-    }
-    }*/
 
 }

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
@@ -1894,6 +1894,26 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                 logger.info(msg);
                 qr.setActive(false);
             }
+	    //Masking applications except the supervisor
+	    if (qr.getResource().getHostName().contains("amc13")) {
+                msg = msgPrefix + "Masking the  application with name "
+                    + qr.getName() + " running on host " + qr.getResource().getHostName();
+                logger.info(msg);
+                qr.setActive(false);
+            }
+	    if (qr.getResource().getHostName().contains("glib")) {
+                msg = msgPrefix + "Masking the  application with name "
+                    + qr.getName() + " running on host " + qr.getResource().getHostName();
+                logger.info(msg);
+                qr.setActive(false);
+            }
+	    if (qr.getResource().getHostName().contains("optohybrid")) {
+                msg = msgPrefix + "Masking the  application with name "
+                    + qr.getName() + " running on host " + qr.getResource().getHostName();
+                logger.info(msg);
+                qr.setActive(false);
+            }
+
         }
 
         logger.info("[GEM "+ m_gemFM.m_FMname + "] SID of QG is " + m_gemQG.getRegistryEntry(GEMParameters.SID));

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
@@ -113,11 +113,13 @@ public class GEMEventHandler extends UserStateNotificationHandler {
      */
     public boolean stopGEMSupervisorWatchThread =  false; 
 
+    public String msgPrefix = "[GEM FM] GEMEventHandler::GEMEventHandler(): ";
+
     public GEMEventHandler()
         throws rcms.fm.fw.EventHandlerException
     {
         // String msgPrefix = "[GEM FM::" + m_gemFM.m_FMname + "] GEMEventHandler::GEMEventHandler(): ";
-        String msgPrefix = "[GEM FM] GEMEventHandler::GEMEventHandler(): ";
+        //String msgPrefix = "[GEM FM] GEMEventHandler::GEMEventHandler(): ";
 
         // this handler inherits UserStateNotificationHandler
         // so it is already registered for StateNotification events

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
@@ -2112,6 +2112,12 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                 qr.setActive(false);
             }
 	    */
+	    if (qr.getResource().getHostName().contains("tcds")) {
+                msg = msgPrefix + "Masking the  application with name "
+                    + qr.getName() + " running on host " + qr.getResource().getHostName();
+                logger.info(msg);
+                qr.setActive(false);
+            }
         }
 
         logger.info("[GEM "+ m_gemFM.m_FMname + "] SID of QG is " + m_gemQG.getRegistryEntry(GEMParameters.SID));
@@ -2414,7 +2420,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 
 			    // ask for the status of the GEM supervisor
 			    for (QualifiedResource qr : m_gemFM.c_gemSupervisors.getApplications() ){
-				logger.info("[GEM " + m_gemFM.m_FMname + "] GEMSupervisorWatchThread(): found qualified resource of GEMSupervisor type");
+				logger.info(msgPrefix + " GEMSupervisorWatchThread(): found qualified resource of GEMSupervisor type");
 				try {
 				    pam =((XdaqApplication)qr).getXDAQParameter();
 				    pam.select(new String[] {"FSMState"}); //This needs to be replaced with StateName, but not working for now
@@ -2423,23 +2429,23 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 				    status = pam.getValue("FSMState");
 				    
 				    if (status==null) {
-					String errMessage = "[GEM " + m_gemFM.m_FMname + "] Error! Asking the GEMSupervisor for the PartitionState and stateName to see if it is alive or not resulted in a NULL pointer - this is bad!";
+					String errMessage = msgPrefix + " Error! Asking the GEMSupervisor for the PartitionState and stateName to see if it is alive or not resulted in a NULL pointer - this is bad!";
 					m_gemFM.goToError(errMessage);
 				    }
 
-				    logger.info("[GEM " + m_gemFM.m_FMname + "] asking for the GEM supervisor PartitionState to see if it is still alive.\n The PartitionState is: " + status);
+				    logger.info(msgPrefix + " asking for the GEM supervisor PartitionState to see if it is still alive.\n The PartitionState is: " + status);
 				}
 				catch (XDAQTimeoutException e) {
-				    String errMessage = "[GEM " + m_gemFM.m_FMname + "] Error! XDAQTimeoutException: GEMSupervisorWatchThread()\nProbably the GEM supervisor application is dead.\nCheck the corresponding jobcontrol status ...\nHere is the exception: " +e;
+				    String errMessage = msgPrefix + " Error! XDAQTimeoutException: GEMSupervisorWatchThread()\nProbably the GEM supervisor application is dead.\nCheck the corresponding jobcontrol status ...\nHere is the exception: " +e;
 				    m_gemFM.goToError(errMessage);
 				}
 				catch (XDAQException e) {
-				    String errMessage = "[GEM " + m_gemFM.m_FMname + "] Error! XDAQException: GEMSupervisorWatchThread()\nProbably the GEM supervisor application is in a bad condition.\nCheck the corresponding jobcontrol status, etc. ...\nHere is the exception: " +e;
+				    String errMessage = msgPrefix + " Error! XDAQException: GEMSupervisorWatchThread()\nProbably the GEM supervisor application is in a bad condition.\nCheck the corresponding jobcontrol status, etc. ...\nHere is the exception: " +e;
 				    m_gemFM.goToError(errMessage);
 				}
 
 				if (status.equals("Failed") || status.equals("Faulty") || status.equals("Error")) {
-				    String errMessage = "[GEM " + m_gemFM.m_FMname + "] Error! GEMSupervisorWatchThread(): supervisor reports partitionState: " + status +"; ";
+				    String errMessage = msgPrefix + " Error! GEMSupervisorWatchThread(): supervisor reports partitionState: " + status +"; ";
 				    //Usefulin case wehave an error string from the supervisor
 				    //String supervisorError = m_gemFM.getSupervisorErrorMessage();
 				    //errMessage+=supervisorError;
@@ -2448,7 +2454,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 			    }
 			}
 			else {
-			    String errMessage = "[GEM " + m_gemFM.m_FMname + "] Error! No GEM supervisor found: GEMSupervisorWatchThread()";
+			    String errMessage = msgPrefix + " Error! No GEM supervisor found: GEMSupervisorWatchThread()";
 			    m_gemFM.goToError(errMessage);
 			}
 		    }
@@ -2459,8 +2465,8 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 	    }
 
 	    // stop the GEM supervisor watchdog thread
-	    System.out.println("[GEM " + m_gemFM.m_FMname + "] ... stopping GEM supervisor watchdog thread done.");
-	    logger.info("[GEM " + m_gemFM.m_FMname + "] ... stopping GEM supervisor watchdog thread done.");
+	    System.out.println(msgPrefix + " ... stopping GEM supervisor watchdog thread done.");
+	    logger.info(msgPrefix + " ... stopping GEM supervisor watchdog thread done.");
 
 	    //GEMSupervisorWatchThreadList.remove(this);
 	}

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
@@ -520,17 +520,17 @@ public class GEMEventHandler extends UserStateNotificationHandler {
             .setValue(new StringT(globalConfKey));
             */
             // go to HALT
-            //m_gemFM.fireEvent(GEMInputs.SETHALTED); 
-	    //We need to assure that all applications (supervisor and managers are in halted state before setting halted in the FM)
-	    boolean isAMC13halted = false;
+            m_gemFM.fireEvent(GEMInputs.SETHALTED); 
+	    //We need to assure that all applications (supervisor and managers are in halted state before setting halted in the FM) in case StateVector from RCMS does not work
+	    /*boolean isAMC13halted = false;
 	    boolean isAMC13Rhalted = false;
 	    boolean isGLIBhalted = false;
 	    boolean isOHhalted = false;
 	    boolean isSupervisorhalted = false;
 	    int htcount = 0;
             while ((isAMC13halted == false) || (isAMC13Rhalted == false) || (isGLIBhalted == false) || (isOHhalted == false) || (isSupervisorhalted == false)){
-		icount++;
-		if (icount%2==0) {
+		htcount++;
+		if (htcount%2==0) {
 		    if (!m_gemFM.c_gemSupervisors.isEmpty() && !isSupervisorhalted) {
 			{
 			    String debugMessage = "[GEM " + m_gemFM.m_FMname + "] GEM supervisor found for checking its state: GEMINI is indeed alive!";
@@ -587,7 +587,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 	    else{
 		String errMessage = "[GEM " + m_gemFM.m_FMname + "] something went wrong! One of the applications or the supervisor is not in halted state";
 		m_gemFM.goToError(errMessage);
-	    }
+		}*/
 
             // set action
             m_gemPSet.put(new FunctionManagerParameter<StringT>(GEMParameters.ACTION_MSG,
@@ -2406,7 +2406,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 			    
 			    {
 				String debugMessage = "[GEM " + m_gemFM.m_FMname + "] GEM supervisor found for checking its state: GEMINI still alive!";
-				logger.debug(debugMessage);
+				logger.info(debugMessage);
 			    }
 
 			    XDAQParameter pam = null;
@@ -2426,11 +2426,11 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 				    stateName = pam.getValue("stateName");
 				    
 				    if (status==null || stateName==null) {
-					String errMessage = "[GEM " + m_gemFM.m_FMname + "] Error! Asking the hcalSupervisor for the PartitionState and stateName to see if it is alive or not resulted in a NULL pointer - this is bad!";
+					String errMessage = "[GEM " + m_gemFM.m_FMname + "] Error! Asking the GEMSupervisor for the PartitionState and stateName to see if it is alive or not resulted in a NULL pointer - this is bad!";
 					m_gemFM.goToError(errMessage);
 				    }
 
-				    logger.debug("[GEM " + m_gemFM.m_FMname + "] asking for the GEM supervisor PartitionState to see if it is still alive.\n The PartitionState is: " + status);
+				    logger.info("[GEM " + m_gemFM.m_FMname + "] asking for the GEM supervisor PartitionState to see if it is still alive.\n The PartitionState is: " + status);
 				}
 				catch (XDAQTimeoutException e) {
 				    String errMessage = "[GEM " + m_gemFM.m_FMname + "] Error! XDAQTimeoutException: GEMSupervisorWatchThread()\nProbably the GEM supervisor application is dead.\nCheck the corresponding jobcontrol status ...\nHere is the exception: " +e;
@@ -2463,7 +2463,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 
 	    // stop the GEM supervisor watchdog thread
 	    System.out.println("[GEM " + m_gemFM.m_FMname + "] ... stopping GEM supervisor watchdog thread done.");
-	    logger.debug("[GEM " + m_gemFM.m_FMname + "] ... stopping GEM supervisor watchdog thread done.");
+	    logger.info("[GEM " + m_gemFM.m_FMname + "] ... stopping GEM supervisor watchdog thread done.");
 
 	    //GEMSupervisorWatchThreadList.remove(this);
 	}

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
@@ -2035,12 +2035,14 @@ public class GEMEventHandler extends UserStateNotificationHandler {
                     logger.info(msgPrefix + "initXDAQ: got parameters, selecting:");
 
                     //pam.select(new String[] {"TriggerAdapterName", "PartitionState", "InitializationProgress","ReportStateToRCMS"});
-                    pam.select(new String[] {"HandleTCDS"});
+                    pam.select(new String[] {"HandleTCDS", "dbPort"});
                     logger.info(msgPrefix + "initXDAQ: parameters selected, getting:");
                     pam.get();
-		    boolean DoesSupervisorHandleTCDS =  pam.getValue("HandleTCDS");
+		    String DoesSupervisorHandleTCDS =  pam.getValue("HandleTCDS");
+		    String WichDBPort = pam.getValue("dbPort");
                     logger.info(msgPrefix + "initXDAQ: got selected parameters!");
 		    logger.info(msgPrefix + "HandleTCDS: " + DoesSupervisorHandleTCDS);
+		    logger.info(msgPrefix + "dbPort: " + WichDBPort);
 
                     dowehaveanasyncgemSupervisor = pam.getValue("ReportStateToRCMS");
                     msg = msgPrefix + "initXDAQ(): asking for the GEM supervisor "

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
@@ -2417,10 +2417,10 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 				logger.info("[GEM " + m_gemFM.m_FMname + "] GEMSupervisorWatchThread(): found qualified resource of GEMSupervisor type");
 				try {
 				    pam =((XdaqApplication)qr).getXDAQParameter();
-				    pam.select(new String[] {"StateName"});
+				    pam.select(new String[] {"FSMState"}); //This needs to be replaced with StateName, but not working for now
 				    pam.get();
 				    
-				    status = pam.getValue("StateName");
+				    status = pam.getValue("FSMState");
 				    
 				    if (status==null) {
 					String errMessage = "[GEM " + m_gemFM.m_FMname + "] Error! Asking the GEMSupervisor for the PartitionState and stateName to see if it is alive or not resulted in a NULL pointer - this is bad!";

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
@@ -2411,21 +2411,18 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 
 			    XDAQParameter pam = null;
 			    String status   = "undefined";
-			    String stateName   = "undefined";
-			    String progress = "undefined";  //Needed?
-			    String taname   = "undefined";  //Needed?
 
 			    // ask for the status of the GEM supervisor
 			    for (QualifiedResource qr : m_gemFM.c_gemSupervisors.getApplications() ){
+				logger.info("[GEM " + m_gemFM.m_FMname + "] GEMSupervisorWatchThread(): found qualified resource of GEMSupervisor type");
 				try {
 				    pam =((XdaqApplication)qr).getXDAQParameter();
-				    pam.select(new String[] {"TriggerAdapterName", "PartitionState", "InitializationProgress", "stateName"});
+				    pam.select(new String[] {"StateName"});
 				    pam.get();
 				    
-				    status = pam.getValue("PartitionState");
-				    stateName = pam.getValue("stateName");
+				    status = pam.getValue("StateName");
 				    
-				    if (status==null || stateName==null) {
+				    if (status==null) {
 					String errMessage = "[GEM " + m_gemFM.m_FMname + "] Error! Asking the GEMSupervisor for the PartitionState and stateName to see if it is alive or not resulted in a NULL pointer - this is bad!";
 					m_gemFM.goToError(errMessage);
 				    }
@@ -2441,8 +2438,8 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 				    m_gemFM.goToError(errMessage);
 				}
 
-				if (status.equals("Failed") || status.equals("Faulty") || status.equals("Error") || stateName.equalsIgnoreCase("failed")) {
-				    String errMessage = "[GEM " + m_gemFM.m_FMname + "] Error! GEMSupervisorWatchThread(): supervisor reports partitionState: " + status + " and stateName: " + stateName +"; ";
+				if (status.equals("Failed") || status.equals("Faulty") || status.equals("Error")) {
+				    String errMessage = "[GEM " + m_gemFM.m_FMname + "] Error! GEMSupervisorWatchThread(): supervisor reports partitionState: " + status +"; ";
 				    //Usefulin case wehave an error string from the supervisor
 				    //String supervisorError = m_gemFM.getSupervisorErrorMessage();
 				    //errMessage+=supervisorError;

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
@@ -454,6 +454,12 @@ public class GEMEventHandler extends UserStateNotificationHandler {
              * PUT YOUR CODE HERE
              ***********************************************/
 
+	    // start the GEMSupervisor watchdog thread
+	    System.out.println("[GEM LVL1 " + m_gemFM.m_FMname + "] Starting GEM supervisor watchdog thread ...");
+	    logger.debug("[GEM LVL1 " + m_gemFM.m_FMname + "] Starting GEM supervisor watchdog thread ...");
+	    GEMSupervisorWatchThread SThread = new GEMSupervisorWatchThread();
+	    SThread.start();
+
             // force TCDS HALTED
             if (m_gemFM.c_tcdsControllers != null) {
                 if (!m_gemFM.c_tcdsControllers.isEmpty()) {

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
@@ -2311,9 +2311,9 @@ public class GEMEventHandler extends UserStateNotificationHandler {
     // thread which checks the GEM supervisor state
     protected class GEMSupervisorWatchThread extends Thread {
 	
-	public GEMSupervisorWatchThread() {
+	/*public GEMSupervisorWatchThread() {
 	    GEMSupervisorWatchThreadList.add(this);
-	}
+	    }*/
 	
 	public void run() {
 	    stopGEMSupervisorWatchThread = false;
@@ -2370,8 +2370,9 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 
 				if (status.equals("Failed") || status.equals("Faulty") || status.equals("Error") || stateName.equalsIgnoreCase("failed")) {
 				    String errMessage = "[GEM " + m_gemFM.m_FMname + "] Error! GEMSupervisorWatchThread(): supervisor reports partitionState: " + status + " and stateName: " + stateName +"; ";
-				    String supervisorError = m_gemFM.getSupervisorErrorMessage();
-				    errMessage+=supervisorError;
+				    //Usefulin case wehave an error string from the supervisor
+				    //String supervisorError = m_gemFM.getSupervisorErrorMessage();
+				    //errMessage+=supervisorError;
 				    m_gemFM.goToError(errMessage);
 				}
 			    }

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMEventHandler.java
@@ -2319,7 +2319,7 @@ public class GEMEventHandler extends UserStateNotificationHandler {
 	    stopGEMSupervisorWatchThread = false;
 	    
 	    int icount = 0;
-	    while ((stopGEMSupervisorWatchThread == false) && (m_gemFM != null) && (m_gemFM.isDestroyed() == false)) {
+	    while ((stopGEMSupervisorWatchThread == false) && (m_gemFM != null)){// && (m_gemFM.isDestroyed() == false)) { //This needs to be uncommented if we include a isDestroyed function in the FM
 		icount++;
 		Date now = Calendar.getInstance().getTime();
 		

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMFunctionManager.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMFunctionManager.java
@@ -168,6 +168,7 @@ public class GEMFunctionManager extends UserFunctionManager {
     public RunInfo GEMRunInfo = null;
 
     // set from the controlled EventHandler
+    protected GEMEventHandler theEventHandler = null;
     public String  RunType = "local";
     public Integer RunNumber = 0;
     //public Integer CachedRunNumber = 0;
@@ -301,6 +302,10 @@ public class GEMFunctionManager extends UserFunctionManager {
         if (RunType.equals("local")) { closeSessionId(); }
         //closeSessionId();  // NEEDS TO BE CORRECTED TO ONLY BE CALLED IN LOCAL RUNS
 
+	//Stop watchthreads before destroying
+	//theEventHandler.stopMonitorThread = true;
+	theEventHandler.stopGEMSupervisorWatchThread = true;
+
         try {
             // retrieve the Function Managers and kill themDestroy all XDAQ applications
             destroyXDAQ();
@@ -359,7 +364,9 @@ public class GEMFunctionManager extends UserFunctionManager {
 
         // Add event handler
         logger.info(msgPrefix + "Adding the GEMEventHandler");
-        addEventHandler(new GEMEventHandler());
+	theEventHandler = new GEMEventHandler();
+	addEventHandler(theEventHandler);
+        //addEventHandler(new GEMEventHandler());
 
         // Add error handler
         logger.info(msgPrefix + "Adding the GEMErrorHandler");

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMFunctionManager.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMFunctionManager.java
@@ -754,9 +754,9 @@ public class GEMFunctionManager extends UserFunctionManager {
         }
     }
 
-    public boolean isDestroyed() {
+    /*public boolean isDestroyed() {
 	return destroyed;
-    }
+	}*/
     /**----------------------------------------------------------------------
      * get all XDAQ executives and kill them
      */

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMFunctionManager.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMFunctionManager.java
@@ -168,7 +168,7 @@ public class GEMFunctionManager extends UserFunctionManager {
     public RunInfo GEMRunInfo = null;
 
     // set from the controlled EventHandler
-    public String  RunType = "";
+    public String  RunType = "local";
     public Integer RunNumber = 0;
     //public Integer CachedRunNumber = 0;
 
@@ -261,10 +261,19 @@ public class GEMFunctionManager extends UserFunctionManager {
         logSessionConnector = getLogSessionConnector();
         logger.info(msgPrefix + "Get log session connector finished");
 
+	getParameterSet().get(GEMParameters.RUN_TYPE).setValue(new StringT(RunType));
         // get session ID // NEEDS TO BE REMOVED FOR GLOBAL OPERATIONS
-        logger.info(msgPrefix + "Get session ID started");
-        getSessionId();
-        logger.info(msgPrefix + "Get session ID finished");
+	if (RunType.equals("local")) {
+	    logger.info(msgPrefix + "Starting SID fetching for run type:" + RunType);
+	    logger.info(msgPrefix + "Get session ID started");
+	    getSessionId();
+	    logger.info(msgPrefix + "Get session ID finished");
+
+	}
+	else {
+	    logger.info(msgPrefix + "No need of fetching SID for run type:" + RunType);
+	    logger.warn("[GEM] logSessionConnector = " + logSessionConnector + ", using default = " + getParameterSet().get(GEMParameters.SID).getValue() + ".");      
+	}
 
         logger.debug(msgPrefix + "createAction executed.");
     }
@@ -289,8 +298,8 @@ public class GEMFunctionManager extends UserFunctionManager {
         logger.debug(msgPrefix + "destroyAction called");
 
         // try to close any open session ID only if we are in local run mode i.e. not CDAQ and not miniDAQ runs and if it's a LV1FM
-        // if (RunType.equals("local") && !containerFMChildren.isEmpty()) { closeSessionId(); }
-        closeSessionId();  // NEEDS TO BE CORRECTED TO ONLY BE CALLED IN LOCAL RUNS
+        if (RunType.equals("local")) { closeSessionId(); }
+        //closeSessionId();  // NEEDS TO BE CORRECTED TO ONLY BE CALLED IN LOCAL RUNS
 
         try {
             // retrieve the Function Managers and kill themDestroy all XDAQ applications

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMFunctionManager.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMFunctionManager.java
@@ -169,6 +169,7 @@ public class GEMFunctionManager extends UserFunctionManager {
 
     // set from the controlled EventHandler
     protected GEMEventHandler theEventHandler = null;
+    protected GEMErrorHandler theErrorHandler = null;
     public String  RunType = "local";
     public Integer RunNumber = 0;
     //public Integer CachedRunNumber = 0;
@@ -370,7 +371,9 @@ public class GEMFunctionManager extends UserFunctionManager {
 
         // Add error handler
         logger.info(msgPrefix + "Adding the GEMErrorHandler");
-        addEventHandler(new GEMErrorHandler());
+	theErrorHandler = new GEMErrorHandler();
+	addEventHandler(theErrorHandler);
+        //addEventHandler(new GEMErrorHandler());
 
         // Add state notification handler
         logger.info(msgPrefix + "Creating the state notification handler");
@@ -481,11 +484,16 @@ public class GEMFunctionManager extends UserFunctionManager {
         getParameterSet().get("ERROR_MSG").setValue(new StringT(errMessage));
 
         // send error
-        try {
+        /*try {
             getParentErrorNotifier().sendError(error);
         } catch (Exception e) {
             logger.warn(msgPrefix + "" + getClass().toString() + ": Failed to send error message " + errMessage);
-        }
+	    }*/
+	try {
+	    theErrorHandler.setError(error);
+        } catch (Exception e) {
+            logger.warn(msgPrefix + "" + getClass().toString() + ": Failed to send error message " + errMessage);
+	}
     }
 
 

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMFunctionManager.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMFunctionManager.java
@@ -492,7 +492,7 @@ public class GEMFunctionManager extends UserFunctionManager {
 	try {
 	    theErrorHandler.setError(error);
         } catch (Exception e) {
-            logger.warn(msgPrefix + "" + getClass().toString() + ": Failed to send error message " + errMessage);
+            logger.warn(msgPrefix + getClass().toString() + ": Failed to send error message " + errMessage);
 	}
     }
 

--- a/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMParameters.java
+++ b/gemLevelOneFM/src/rcms/fm/app/gemfm/GEMParameters.java
@@ -53,6 +53,7 @@ public class GEMParameters {
 
     // Command parameters
     public static final String SID             = "SID";
+    public static final String RUN_TYPE             = "RUN_TYPE";
     public static final String GLOBAL_CONF_KEY = "GLOBAL_CONF_KEY";
 
     public static final String RUN_NUMBER     = "RUN_NUMBER";
@@ -104,6 +105,8 @@ public class GEMParameters {
         // Database connection session identifier
         LVL_ONE_PARAMETER_SET.put(new FunctionManagerParameter<IntegerT> (SID, new IntegerT(0),
                                                                           Exported.READONLY) );
+        LVL_ONE_PARAMETER_SET.put(new FunctionManagerParameter<StringT>(RUN_TYPE, new StringT("not set"),
+                                                                        Exported.READONLY) );
         LVL_ONE_PARAMETER_SET.put(new FunctionManagerParameter<StringT>(GLOBAL_CONF_KEY, new StringT("not set"),
                                                                         Exported.READONLY) );
         LVL_ONE_PARAMETER_SET.put(new FunctionManagerParameter<IntegerT>(RUN_NUMBER, new IntegerT(-1),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding new feature to create SID only if the run type is local

A new parameter StringT has been added: RUN_TYPE
If it is local, a SID is created, if not SID=0

For the moment this parameter is hardcoded and local by default. Will need to find a better way to configure it on the go.

Accordingly the session ID is only closed if running in local mode.
<!--- Describe your changes in detail -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Changes needed to run in global mode.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It has been tested at 904 with uFEDKIT + TCDS config.

It has been tested that when moving to global config no new session is created.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
